### PR TITLE
Auto-detect ArgoCD credentials and drop --in-cluster

### DIFF
--- a/.github/workflows/ci-docker.yaml
+++ b/.github/workflows/ci-docker.yaml
@@ -141,6 +141,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -169,18 +170,18 @@ jobs:
           context: .
           file: docker/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Install Helm
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
         uses: azure/setup-helm@v4
         with:
           version: v3.14.0
 
       - name: Package and push Helm chart
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
         run: |
           # Match the short SHA format used by docker/metadata-action type=sha.
           # workflow_run: github.sha is NOT the triggering commit; use head_sha.

--- a/MOVE_TO_RUST.md
+++ b/MOVE_TO_RUST.md
@@ -133,7 +133,7 @@ The Rust binary is **pre-built by CI** and provided in the Docker build context.
 2. **`docker/plugin.yaml`** (line 37)
    ```yaml
    # OLD:
-   nyl template --in-cluster .
+   nyl template .
 
    # NEW:
    nyl render .

--- a/MOVE_TO_RUST.md
+++ b/MOVE_TO_RUST.md
@@ -133,7 +133,7 @@ The Rust binary is **pre-built by CI** and provided in the Docker build context.
 2. **`docker/plugin.yaml`** (line 37)
    ```yaml
    # OLD:
-   nyl template .
+   nyl template --in-cluster .
 
    # NEW:
    nyl render .

--- a/MOVE_TO_RUST.md
+++ b/MOVE_TO_RUST.md
@@ -136,7 +136,7 @@ The Rust binary is **pre-built by CI** and provided in the Docker build context.
    nyl template --in-cluster .
 
    # NEW:
-   nyl render --in-cluster .
+   nyl render .
    ```
 
 3. **`chart/` (formerly `argocd-with-nyl/`)**

--- a/chart/README.md
+++ b/chart/README.md
@@ -154,7 +154,7 @@ If you're upgrading from the Python version of Nyl, here's what you need to know
 
 4. **Test your manifests** with the Rust version:
    ```bash
-   nyl render . > /tmp/output.yaml
+   nyl render manifest.yaml > /tmp/output.yaml
    kubectl diff -f /tmp/output.yaml
    ```
 

--- a/chart/templates/argocd-helmchart.yaml
+++ b/chart/templates/argocd-helmchart.yaml
@@ -23,7 +23,7 @@ spec:
     
     {{- /* Build Nyl container configuration */ -}}
     {{- $nylContainer := dict 
-      "name" "nyl-v1"
+      "name" "nyl-v2"
       "image" (printf "%s:%s" .Values.nyl.image.repository .Values.nyl.image.tag)
       "imagePullPolicy" .Values.nyl.image.pullPolicy
       "securityContext" .Values.nyl.securityContext

--- a/docker/plugin.yaml
+++ b/docker/plugin.yaml
@@ -34,7 +34,12 @@ spec:
       - sh
       - -c
       - |
-        nyl render .
+        TEMPLATE_INPUT="${ARGOCD_ENV_NYL_CMP_TEMPLATE_INPUT:-${NYL_CMP_TEMPLATE_INPUT:-}}"
+        if [ -z "$TEMPLATE_INPUT" ]; then
+          echo "NYL_CMP_TEMPLATE_INPUT is required. Set it via Application source.plugin.env." >&2
+          exit 1
+        fi
+        nyl render "$TEMPLATE_INPUT"
 
   parameters: {}
 

--- a/docker/plugin.yaml
+++ b/docker/plugin.yaml
@@ -4,10 +4,9 @@
 apiVersion: argoproj.io/v1alpha1
 kind: ConfigManagementPlugin
 metadata:
-  name: nyl
+  name: nyl-v2
 spec:
-  # note: Plugin name in ArgoCD will be `nyl-v1`.
-  version: v1
+  # note: Plugin name in ArgoCD is `nyl-v2`.
 
   discover:
     find:

--- a/docker/plugin.yaml
+++ b/docker/plugin.yaml
@@ -34,7 +34,7 @@ spec:
       - sh
       - -c
       - |
-        nyl render --in-cluster .
+        nyl render .
 
   parameters: {}
 

--- a/integrationtests/README.md
+++ b/integrationtests/README.md
@@ -29,6 +29,76 @@ Each test is a standalone bash script that:
 ```bash
 ./test-kind-filtering-append-release.sh
 ./test-argocd-bootstrap.sh
+./test-argocd-credential-lookup-local.sh
+```
+
+### Run ArgoCD credential lookup test (opt-in)
+
+This test validates in-cluster ArgoCD repository secret discovery and requires
+access to a private repository.
+
+```bash
+TEST_REPO_URL="https://github.com/your-org/your-private-repo.git" \
+TEST_REPO_USERNAME="your-username" \
+TEST_REPO_PASSWORD="your-token" \
+./test-argocd-credential-lookup-local.sh
+```
+
+By default, the test uses `debian:bookworm-slim` as runner pod image and
+uses a statically linked musl `nyl` binary (no libc runtime packages required).
+
+The `nyl` binary is auto-detected from cargo target directories (newest of):
+- `target/x86_64-unknown-linux-musl/debug/nyl`
+- `target/x86_64-unknown-linux-musl/release/nyl`
+- `nyl/target/x86_64-unknown-linux-musl/debug/nyl`
+- `nyl/target/x86_64-unknown-linux-musl/release/nyl`
+- `target/debug/nyl`
+- `target/release/nyl`
+- `nyl/target/debug/nyl`
+- `nyl/target/release/nyl`
+
+Override with `NYL_BIN=/path/to/nyl` or `RUNNER_IMAGE=...` if needed.
+By default, the test now runs:
+
+```bash
+cargo build -p nyl --target x86_64-unknown-linux-musl
+```
+
+The script automatically:
+- ensures rust target `x86_64-unknown-linux-musl` is installed (`rustup target add ...`)
+- sets linker env vars:
+  - `CC_x86_64_unknown_linux_musl`
+  - `CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER`
+  using `musl-gcc` (or `x86_64-linux-musl-gcc`)
+
+If no musl linker is found, it exits with install instructions (e.g. `musl-tools` on Debian/Ubuntu).
+
+Set `NYL_SKIP_BUILD=true` to skip this automatic build step, or set
+`NYL_BIN=/path/to/nyl` to use a specific binary.
+
+CA certificates in the pod are controlled via `INSTALL_CA_CERTS`:
+- `auto` (default): installs CA certs when `TEST_REPO_URL` starts with `https://`
+- `true`: always install CA certs
+- `false`: never install CA certs
+
+The runner pod defaults to namespace `argocd` (same namespace used for ArgoCD
+secret discovery). Override with `RUNNER_NAMESPACE=...` if needed.
+
+Strict private-repo validation is enabled by default:
+- `REQUIRE_PRIVATE_REPO=true` (default)
+
+In this mode, the test fails if Case A succeeds without a secret.
+Set `REQUIRE_PRIVATE_REPO=false` only if you intentionally want to run against
+publicly readable repositories.
+
+To include it in `run-all.sh`:
+
+```bash
+RUN_ARGOCD_CREDENTIAL_LOOKUP_TEST=true \
+TEST_REPO_URL="https://github.com/your-org/your-private-repo.git" \
+TEST_REPO_USERNAME="your-username" \
+TEST_REPO_PASSWORD="your-token" \
+./run-all.sh
 ```
 
 ### Run with fresh cluster (recommended for CI)
@@ -77,6 +147,21 @@ Tests ArgoCD deployment using the Nyl Helm chart OCI image with staged deploymen
 **Resources:** ArgoCD namespace with full ArgoCD installation (~10 deployments/statefulsets)
 **Prerequisites:** Helm CLI installed
 **Optional:** `GITHUB_TOKEN` and `GITHUB_ACTOR` environment variables for OCI registry authentication
+
+### test-argocd-credential-lookup-local.sh
+
+Tests ArgoCD repository secret discovery in a live cluster:
+- Runs local `nyl` binary inside a pod (in-cluster mode)
+- Creates an `ApplicationGenerator` that points to a private Git repository
+- Verifies render fails without ArgoCD repository secret
+- Creates `argocd.argoproj.io/secret-type=repository` secret
+- Verifies render succeeds with discovered credentials
+
+**Duration:** ~30-90 seconds (excluding network clone latency)
+**Resources:** 1 temporary test namespace + RBAC/Secret in `argocd`
+**Required:** `TEST_REPO_URL`, `TEST_REPO_USERNAME`, `TEST_REPO_PASSWORD`
+**Optional:** `NYL_BIN`, `NYL_SKIP_BUILD`, `RUNNER_IMAGE` (default: `debian:bookworm-slim`), `INSTALL_CA_CERTS` (default: `auto`), `RUNNER_NAMESPACE` (default: `argocd`), `REQUIRE_PRIVATE_REPO` (default: `true`)
+**Default behavior:** skipped by `run-all.sh` unless `RUN_ARGOCD_CREDENTIAL_LOOKUP_TEST=true`
 
 ## Writing New Tests
 

--- a/integrationtests/run-all.sh
+++ b/integrationtests/run-all.sh
@@ -6,6 +6,11 @@ set -euo pipefail
 # Usage:
 #   ./run-all.sh              # Run all tests against existing cluster
 #   ./run-all.sh --recreate   # Recreate Minikube between each test (slow but isolated)
+#
+# Optional environment variables:
+#   RUN_ARGOCD_CREDENTIAL_LOOKUP_TEST=true
+#     Include test-argocd-credential-lookup-local.sh in the test run.
+#     This test requires TEST_REPO_URL, TEST_REPO_USERNAME, TEST_REPO_PASSWORD.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RECREATE_CLUSTER=false
@@ -34,7 +39,15 @@ echo "✓ Prerequisites verified"
 echo ""
 
 # Find all test scripts
-TEST_SCRIPTS=($(find "${SCRIPT_DIR}" -name "test-*.sh" -type f | sort))
+TEST_SCRIPTS=()
+while IFS= read -r script; do
+    test_name=$(basename "${script}")
+    if [ "${test_name}" = "test-argocd-credential-lookup-local.sh" ] && \
+        [ "${RUN_ARGOCD_CREDENTIAL_LOOKUP_TEST:-false}" != "true" ]; then
+        continue
+    fi
+    TEST_SCRIPTS+=("${script}")
+done < <(find "${SCRIPT_DIR}" -name "test-*.sh" -type f | sort)
 
 if [ ${#TEST_SCRIPTS[@]} -eq 0 ]; then
     echo "ERROR: No test scripts found in ${SCRIPT_DIR}"
@@ -42,6 +55,9 @@ if [ ${#TEST_SCRIPTS[@]} -eq 0 ]; then
 fi
 
 echo "Found ${#TEST_SCRIPTS[@]} integration test(s)"
+if [ "${RUN_ARGOCD_CREDENTIAL_LOOKUP_TEST:-false}" != "true" ]; then
+    echo "Note: skipping test-argocd-credential-lookup-local.sh (set RUN_ARGOCD_CREDENTIAL_LOOKUP_TEST=true to include)"
+fi
 echo ""
 
 # Track results

--- a/integrationtests/test-argocd-credential-lookup-local.sh
+++ b/integrationtests/test-argocd-credential-lookup-local.sh
@@ -1,0 +1,440 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Integration test: ArgoCD credential lookup (local cluster)
+#
+# This test validates that Nyl discovers ArgoCD repository secrets when running
+# in-cluster and uses them for Git authentication.
+#
+# Required environment variables:
+#   TEST_REPO_URL       - Private Git repository URL (e.g. https://github.com/org/repo.git)
+#   TEST_REPO_USERNAME  - Username for HTTPS auth
+#   TEST_REPO_PASSWORD  - Token/password for HTTPS auth
+#
+# Optional:
+#   TEST_SOURCE_PATH    - Path inside the repo to scan (default: .)
+#   NYL_BIN             - Explicit path to nyl binary (default: auto-detect from cargo target dirs)
+#   NYL_SKIP_BUILD      - Set to "true" to skip automatic cargo build
+#   INSTALL_CA_CERTS    - true|false|auto (default: auto; installs for https:// TEST_REPO_URL)
+#   REQUIRE_PRIVATE_REPO - Set to "false" to allow public-repo behavior (default: true)
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_NAME="argocd-credential-lookup-local"
+ARGOCD_NAMESPACE="argocd"
+RUNNER_NAMESPACE="${RUNNER_NAMESPACE:-${ARGOCD_NAMESPACE}}"
+POD_NAME="nyl-credtest-runner"
+SECRET_NAME="nyl-credtest-repo"
+ROLE_NAME="nyl-credtest-secret-reader"
+MANIFEST_FILE="/tmp/apps.yaml"
+TEST_SOURCE_PATH="${TEST_SOURCE_PATH:-.}"
+RUNNER_IMAGE="${RUNNER_IMAGE:-debian:bookworm-slim}"
+INSTALL_CA_CERTS="${INSTALL_CA_CERTS:-auto}"
+REQUIRE_PRIVATE_REPO="${REQUIRE_PRIVATE_REPO:-true}"
+
+echo "==================================="
+echo "Integration Test: ${TEST_NAME}"
+echo "==================================="
+if [ -z "${TEST_REPO_URL:-}" ] || [ -z "${TEST_REPO_USERNAME:-}" ] || [ -z "${TEST_REPO_PASSWORD:-}" ]; then
+    echo "ERROR: Missing required environment variables."
+    echo "Set TEST_REPO_URL, TEST_REPO_USERNAME, and TEST_REPO_PASSWORD."
+    exit 1
+fi
+
+cleanup() {
+    echo ""
+    echo "Cleaning up test resources..."
+    kubectl -n "${RUNNER_NAMESPACE}" delete pod "${POD_NAME}" --ignore-not-found=true >/dev/null 2>&1 || true
+    kubectl -n "${ARGOCD_NAMESPACE}" delete secret "${SECRET_NAME}" --ignore-not-found=true >/dev/null 2>&1 || true
+    kubectl -n "${ARGOCD_NAMESPACE}" delete role "${ROLE_NAME}" --ignore-not-found=true >/dev/null 2>&1 || true
+    kubectl -n "${ARGOCD_NAMESPACE}" delete rolebinding "${ROLE_NAME}" --ignore-not-found=true >/dev/null 2>&1 || true
+
+    if [ "${RUNNER_NAMESPACE_CREATED_BY_TEST:-false}" = "true" ]; then
+        kubectl delete namespace "${RUNNER_NAMESPACE}" --ignore-not-found=true >/dev/null 2>&1 || true
+    fi
+
+    # Only delete argocd namespace if this test created it.
+    if [ "${ARGOCD_NAMESPACE_CREATED_BY_TEST:-false}" = "true" ]; then
+        kubectl delete namespace "${ARGOCD_NAMESPACE}" --ignore-not-found=true >/dev/null 2>&1 || true
+    fi
+    echo "✓ Cleanup complete"
+}
+trap cleanup EXIT
+
+resolve_local_nyl_bin() {
+    if [ -n "${NYL_BIN:-}" ]; then
+        if [ ! -x "${NYL_BIN}" ]; then
+            echo "ERROR: NYL_BIN is set but not executable: ${NYL_BIN}"
+            exit 1
+        fi
+        echo "${NYL_BIN}"
+        return
+    fi
+
+    local candidates=(
+        "${PROJECT_ROOT}/target/x86_64-unknown-linux-musl/debug/nyl"
+        "${PROJECT_ROOT}/target/x86_64-unknown-linux-musl/release/nyl"
+        "${PROJECT_ROOT}/nyl/target/x86_64-unknown-linux-musl/debug/nyl"
+        "${PROJECT_ROOT}/nyl/target/x86_64-unknown-linux-musl/release/nyl"
+        "${PROJECT_ROOT}/target/debug/nyl"
+        "${PROJECT_ROOT}/target/release/nyl"
+        "${PROJECT_ROOT}/nyl/target/debug/nyl"
+        "${PROJECT_ROOT}/nyl/target/release/nyl"
+    )
+    local newest=""
+    local newest_mtime=0
+
+    for bin in "${candidates[@]}"; do
+        if [ -x "${bin}" ]; then
+            local mtime
+            mtime="$(stat -c %Y "${bin}" 2>/dev/null || echo 0)"
+            if [ "${mtime}" -gt "${newest_mtime}" ]; then
+                newest="${bin}"
+                newest_mtime="${mtime}"
+            fi
+        fi
+    done
+
+    if [ -z "${newest}" ]; then
+        echo "ERROR: Could not find built nyl binary in target directories."
+        echo "Expected one of:"
+        printf '  - %s\n' "${candidates[@]}"
+        echo "Build it first, e.g.: cargo build -p nyl"
+        exit 1
+    fi
+
+    echo "${newest}"
+}
+
+echo "Checking prerequisites..."
+if ! command -v kubectl >/dev/null 2>&1; then
+    echo "ERROR: kubectl not found in PATH"
+    exit 1
+fi
+if ! kubectl cluster-info >/dev/null 2>&1; then
+    echo "ERROR: Cannot connect to Kubernetes cluster"
+    exit 1
+fi
+
+if [ -z "${NYL_BIN:-}" ] && [ "${NYL_SKIP_BUILD:-false}" != "true" ]; then
+    if ! command -v cargo >/dev/null 2>&1; then
+        echo "ERROR: cargo not found in PATH (required for automatic build)."
+        echo "Either install cargo or set NYL_BIN=/path/to/nyl."
+        exit 1
+    fi
+
+    if ! command -v rustup >/dev/null 2>&1; then
+        echo "ERROR: rustup not found in PATH."
+        echo "Install rustup or set NYL_BIN=/path/to/nyl to skip automatic build."
+        exit 1
+    fi
+
+    # Ensure musl target + linker are available for reproducible in-pod execution.
+    if ! rustup target list --installed | grep -q '^x86_64-unknown-linux-musl$'; then
+        echo "Installing Rust target: x86_64-unknown-linux-musl"
+        if ! rustup target add x86_64-unknown-linux-musl; then
+            echo "ERROR: Failed to install rust target x86_64-unknown-linux-musl."
+            echo "Run manually: rustup target add x86_64-unknown-linux-musl"
+            exit 1
+        fi
+    fi
+
+    if command -v musl-gcc >/dev/null 2>&1; then
+        export CC_x86_64_unknown_linux_musl="musl-gcc"
+        export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="musl-gcc"
+    elif command -v x86_64-linux-musl-gcc >/dev/null 2>&1; then
+        export CC_x86_64_unknown_linux_musl="x86_64-linux-musl-gcc"
+        export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="x86_64-linux-musl-gcc"
+    else
+        echo "ERROR: musl linker not found (need musl-gcc or x86_64-linux-musl-gcc)."
+        echo "Install it, for example on Debian/Ubuntu:"
+        echo "  sudo apt-get update && sudo apt-get install -y musl-tools"
+        echo ""
+        echo "Or set NYL_BIN to a prebuilt musl binary and rerun."
+        exit 1
+    fi
+
+    echo "Building nyl binary for musl target (x86_64-unknown-linux-musl)..."
+    if ! (cd "${PROJECT_ROOT}" && cargo build -p nyl --target x86_64-unknown-linux-musl); then
+        echo "ERROR: Failed to build nyl for x86_64-unknown-linux-musl."
+        echo "Using linker: ${CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER:-unset}"
+        echo "Set NYL_BIN to a prebuilt binary to bypass automatic build."
+        exit 1
+    fi
+    echo "✓ Build complete"
+fi
+
+LOCAL_NYL_BIN="$(resolve_local_nyl_bin)"
+echo "✓ Prerequisites verified"
+echo "  nyl binary: ${LOCAL_NYL_BIN}"
+NYL_VERSION="$("${LOCAL_NYL_BIN}" --version 2>/dev/null || true)"
+if [ -z "${NYL_VERSION}" ]; then
+    NYL_VERSION="unknown (could not query via --version)"
+fi
+echo "  nyl version: ${NYL_VERSION}"
+echo ""
+
+ARGOCD_NAMESPACE_CREATED_BY_TEST=false
+if ! kubectl get namespace "${ARGOCD_NAMESPACE}" >/dev/null 2>&1; then
+    kubectl create namespace "${ARGOCD_NAMESPACE}" >/dev/null
+    ARGOCD_NAMESPACE_CREATED_BY_TEST=true
+fi
+
+RUNNER_NAMESPACE_CREATED_BY_TEST=false
+if ! kubectl get namespace "${RUNNER_NAMESPACE}" >/dev/null 2>&1; then
+    kubectl create namespace "${RUNNER_NAMESPACE}" >/dev/null
+    RUNNER_NAMESPACE_CREATED_BY_TEST=true
+fi
+
+echo "Granting ${RUNNER_NAMESPACE}/default secret-read access in ${ARGOCD_NAMESPACE}..."
+kubectl -n "${ARGOCD_NAMESPACE}" apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ${ROLE_NAME}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ${ROLE_NAME}
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: ${RUNNER_NAMESPACE}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ${ROLE_NAME}
+EOF
+echo "✓ RBAC configured"
+echo ""
+
+echo "Starting test runner pod..."
+kubectl -n "${RUNNER_NAMESPACE}" run "${POD_NAME}" --image="${RUNNER_IMAGE}" --restart=Never --command -- sleep 3600
+kubectl -n "${RUNNER_NAMESPACE}" wait --for=condition=Ready "pod/${POD_NAME}" --timeout=120s
+echo "✓ Runner pod ready"
+echo ""
+
+# For static musl builds no runtime libc packages are required.
+# Ensure git is available for worktree operations. Install CA certs only when explicitly
+# requested or when auto-detected for HTTPS.
+SHOULD_INSTALL_CA_CERTS=false
+case "${INSTALL_CA_CERTS}" in
+    true)
+        SHOULD_INSTALL_CA_CERTS=true
+        ;;
+    false)
+        SHOULD_INSTALL_CA_CERTS=false
+        ;;
+    auto)
+        if [[ "${TEST_REPO_URL}" == https://* ]]; then
+            SHOULD_INSTALL_CA_CERTS=true
+        fi
+        ;;
+    *)
+        echo "ERROR: INSTALL_CA_CERTS must be one of: true, false, auto"
+        exit 1
+        ;;
+esac
+
+echo "Ensuring git is available in pod..."
+set +e
+kubectl -n "${RUNNER_NAMESPACE}" exec "${POD_NAME}" -- env WANT_CA_CERTS="${SHOULD_INSTALL_CA_CERTS}" sh -c '
+if command -v git >/dev/null 2>&1; then
+  exit 0
+fi
+pkgs="git"
+if [ "${WANT_CA_CERTS}" = "true" ]; then
+  pkgs="${pkgs} ca-certificates"
+fi
+if command -v apt-get >/dev/null 2>&1; then
+  apt-get update && apt-get install -y --no-install-recommends ${pkgs} && rm -rf /var/lib/apt/lists/*
+elif command -v apk >/dev/null 2>&1; then
+  apk add --no-cache ${pkgs}
+elif command -v microdnf >/dev/null 2>&1; then
+  microdnf install -y ${pkgs} && microdnf clean all
+elif command -v dnf >/dev/null 2>&1; then
+  dnf install -y ${pkgs} && dnf clean all
+elif command -v yum >/dev/null 2>&1; then
+  yum install -y ${pkgs} && yum clean all
+else
+  echo "No supported package manager found to install: ${pkgs}" >&2
+  exit 127
+fi
+'
+INSTALL_DEPS_RC=$?
+set -e
+if [ "${INSTALL_DEPS_RC}" -ne 0 ]; then
+    echo "ERROR: Failed to ensure git in runner pod."
+    echo "The runner image '${RUNNER_IMAGE}' may not include a package manager (common with BusyBox)."
+    echo "Use a runner image with package manager support, e.g.:"
+    echo "  RUNNER_IMAGE=debian:bookworm-slim ./integrationtests/test-argocd-credential-lookup-local.sh"
+    kubectl -n "${RUNNER_NAMESPACE}" exec "${POD_NAME}" -- sh -c "cat /etc/os-release 2>/dev/null || true"
+    exit 1
+fi
+kubectl -n "${RUNNER_NAMESPACE}" exec "${POD_NAME}" -- git --version >/dev/null 2>&1 || {
+    echo "ERROR: git is still not available in runner pod after installation attempt."
+    exit 1
+}
+echo "✓ git available in pod"
+if [ "${SHOULD_INSTALL_CA_CERTS}" = "true" ]; then
+    echo "✓ CA certificates requested for HTTPS repositories"
+else
+    echo "CA certificate installation not requested"
+fi
+echo ""
+
+echo "Copying local nyl binary into pod..."
+kubectl -n "${RUNNER_NAMESPACE}" exec -i "${POD_NAME}" -- sh -c "cat > /tmp/nyl && chmod +x /tmp/nyl" < "${LOCAL_NYL_BIN}"
+kubectl -n "${RUNNER_NAMESPACE}" exec "${POD_NAME}" -- test -x /tmp/nyl
+echo "✓ Nyl binary copied"
+echo ""
+
+echo "Preflight: validating /tmp/nyl runs in pod..."
+set +e
+kubectl -n "${RUNNER_NAMESPACE}" exec "${POD_NAME}" -- /tmp/nyl --help >/tmp/${TEST_NAME}-preflight.log 2>&1
+PREFLIGHT_RC=$?
+set -e
+if [ "${PREFLIGHT_RC}" -ne 0 ]; then
+    echo "ERROR: /tmp/nyl is not runnable in runner pod."
+    echo "This is usually a libc mismatch. Prefer a musl build, e.g.:"
+    echo "  cargo build -p nyl --target x86_64-unknown-linux-musl"
+    cat /tmp/${TEST_NAME}-preflight.log || true
+    exit 1
+fi
+echo "✓ /tmp/nyl is runnable"
+echo ""
+
+echo "Creating ApplicationGenerator manifest inside pod..."
+MANIFEST_TMP="$(mktemp)"
+cat > "${MANIFEST_TMP}" <<EOF
+apiVersion: argocd.nyl.niklasrosenstein.github.com/v1
+kind: ApplicationGenerator
+metadata:
+  name: cred-test
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  source:
+    repoURL: ${TEST_REPO_URL}
+    targetRevision: HEAD
+    path: ${TEST_SOURCE_PATH}
+EOF
+kubectl -n "${RUNNER_NAMESPACE}" exec -i "${POD_NAME}" -- sh -c "cat > '${MANIFEST_FILE}'" < "${MANIFEST_TMP}"
+rm -f "${MANIFEST_TMP}"
+echo "✓ Manifest created"
+if ! kubectl -n "${RUNNER_NAMESPACE}" exec "${POD_NAME}" -- sh -c "test -s '${MANIFEST_FILE}'"; then
+    echo "ERROR: Manifest file was not created or is empty: ${MANIFEST_FILE}"
+    kubectl -n "${RUNNER_NAMESPACE}" exec "${POD_NAME}" -- sh -c "ls -la /tmp" || true
+    exit 1
+fi
+if ! kubectl -n "${RUNNER_NAMESPACE}" exec "${POD_NAME}" -- sh -c \
+    "grep -q '^apiVersion: argocd.nyl.niklasrosenstein.github.com/v1$' '${MANIFEST_FILE}' && grep -q '^kind: ApplicationGenerator$' '${MANIFEST_FILE}'"; then
+    echo "ERROR: Generated manifest does not look like an ApplicationGenerator."
+    kubectl -n "${RUNNER_NAMESPACE}" exec "${POD_NAME}" -- sh -c "sed -n '1,120p' '${MANIFEST_FILE}'" || true
+    exit 1
+fi
+echo "✓ Manifest shape validated"
+echo ""
+
+echo "Case A: no ArgoCD repository secret (expected: failure)"
+set +e
+CASE_A_OUTPUT="$(
+kubectl -n "${RUNNER_NAMESPACE}" exec "${POD_NAME}" -- env \
+    ARGOCD_APP_NAME=cred-test \
+    ARGOCD_APP_NAMESPACE=argocd \
+    RUST_LOG=nyl=trace,nyl::git=trace \
+    /tmp/nyl render "${MANIFEST_FILE}" 2>&1
+)"
+CASE_A_RC=${PIPESTATUS[0]}
+set -e
+printf '%s\n' "${CASE_A_OUTPUT}"
+
+CASE_A_OUTCOME="failed_without_secret"
+if [ "${CASE_A_RC}" -eq 0 ]; then
+    echo "⚠️  Case A succeeded without secret."
+    echo "   This usually means ${TEST_REPO_URL} is publicly readable from the pod."
+    CASE_A_OUTCOME="succeeded_without_secret"
+    if [ "${REQUIRE_PRIVATE_REPO}" = "true" ]; then
+        echo "ERROR: REQUIRE_PRIVATE_REPO=true but Case A succeeded."
+        echo "Use a private repository URL for TEST_REPO_URL."
+        exit 1
+    fi
+    echo "   Continuing because REQUIRE_PRIVATE_REPO=false."
+else
+    if ! printf '%s\n' "${CASE_A_OUTPUT}" | grep -E -q "No credentials|Authentication failed|Failed to discover ArgoCD credentials|git fetch failed"; then
+        echo "ERROR: Case A failed, but not due to expected auth/credential path."
+        echo "Log excerpt:"
+        printf '%s\n' "${CASE_A_OUTPUT}" | sed -n '1,120p' || true
+        exit 1
+    fi
+    echo "✓ Failed as expected without secret"
+fi
+echo ""
+
+echo "Creating ArgoCD repository secret in ${ARGOCD_NAMESPACE}..."
+kubectl -n "${ARGOCD_NAMESPACE}" create secret generic "${SECRET_NAME}" \
+    --from-literal=url="${TEST_REPO_URL}" \
+    --from-literal=username="${TEST_REPO_USERNAME}" \
+    --from-literal=password="${TEST_REPO_PASSWORD}" \
+    --from-literal=type=git \
+    --dry-run=client -o yaml \
+    | kubectl -n "${ARGOCD_NAMESPACE}" label --local -f - argocd.argoproj.io/secret-type=repository -o yaml \
+    | kubectl apply -f - >/dev/null
+echo "✓ Repository secret created"
+echo ""
+
+echo "Case B: ArgoCD repository secret present (expected: success)"
+set +e
+CASE_B_OUTPUT="$(
+kubectl -n "${RUNNER_NAMESPACE}" exec "${POD_NAME}" -- env \
+    ARGOCD_APP_NAME=cred-test \
+    ARGOCD_APP_NAMESPACE=argocd \
+    RUST_LOG=nyl=trace,nyl::git=trace \
+    /tmp/nyl render "${MANIFEST_FILE}" 2>&1
+)"
+CASE_B_RC=${PIPESTATUS[0]}
+set -e
+printf '%s\n' "${CASE_B_OUTPUT}"
+if [ "${CASE_B_RC}" -ne 0 ]; then
+    echo "ERROR: Expected success with secret, but command failed."
+    exit 1
+fi
+echo "✓ Succeeded with secret"
+echo ""
+
+echo "Rendered manifests from Case B (RUST_LOG=error):"
+RENDERED_OUTPUT="$(
+kubectl -n "${RUNNER_NAMESPACE}" exec "${POD_NAME}" -- env \
+    ARGOCD_APP_NAME=cred-test \
+    ARGOCD_APP_NAMESPACE=argocd \
+    RUST_LOG=error \
+    /tmp/nyl render "${MANIFEST_FILE}" 2>/dev/null || true
+)"
+if [ -z "${RENDERED_OUTPUT}" ]; then
+    echo "  (no manifests rendered)"
+else
+    echo "----- BEGIN RENDERED MANIFESTS -----"
+    printf '%s\n' "${RENDERED_OUTPUT}"
+    echo "----- END RENDERED MANIFESTS -----"
+    KIND_COUNT="$(printf '%s\n' "${RENDERED_OUTPUT}" | grep -c '^kind:' || true)"
+    echo "  Rendered resource count (by 'kind:' lines): ${KIND_COUNT}"
+fi
+echo ""
+
+echo "==================================="
+echo "✅ TEST PASSED: ${TEST_NAME}"
+echo "==================================="
+echo "Summary:"
+echo "  - In-cluster execution path activated via ARGOCD_APP_* env vars"
+if [ "${CASE_A_OUTCOME}" = "failed_without_secret" ]; then
+    echo "  - Render failed without ArgoCD repository secret"
+else
+    echo "  - Render succeeded without secret (repo likely public)"
+fi
+echo "  - Render succeeded after creating repository secret"
+echo ""

--- a/nyl/CHANGELOG.md
+++ b/nyl/CHANGELOG.md
@@ -29,6 +29,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nyl diff manifest.yaml
   ```
 
+- **BREAKING**: ArgoCD Nyl plugin now requires `NYL_CMP_TEMPLATE_INPUT` to select a single manifest file
+  - Plugin command no longer falls back to `nyl render .`
+  - `ApplicationGenerator` and `nyl generate` now set `NYL_CMP_TEMPLATE_INPUT` in generated ArgoCD `Application` plugin env
+
+  **Migration Guide:**
+
+  If you manage ArgoCD Applications manually, add:
+  ```yaml
+  spec:
+    source:
+      plugin:
+        name: nyl
+        env:
+          - name: NYL_CMP_TEMPLATE_INPUT
+            value: apps.yaml
+  ```
+
 - **BREAKING**: Removed `Root` scope from Kyverno policy annotations
   - `Root` and `Global` scopes would be identical since Nyl processes single files
   - Only `Global`, `Subtree`, and `Immediate` scopes are now valid

--- a/nyl/CHANGELOG.md
+++ b/nyl/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING**: ArgoCD Nyl plugin now requires `NYL_CMP_TEMPLATE_INPUT` to select a single manifest file
   - Plugin command no longer falls back to `nyl render .`
   - `ApplicationGenerator` and `nyl generate` now set `NYL_CMP_TEMPLATE_INPUT` in generated ArgoCD `Application` plugin env
+  - Plugin name is now `nyl-v2` (legacy `nyl`/`nyl-v1` references are no longer supported)
 
   **Migration Guide:**
 
@@ -40,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   spec:
     source:
       plugin:
-        name: nyl
+        name: nyl-v2
         env:
           - name: NYL_CMP_TEMPLATE_INPUT
             value: apps.yaml

--- a/nyl/book/src/argocd/application-generator.md
+++ b/nyl/book/src/argocd/application-generator.md
@@ -363,6 +363,8 @@ spec:
     plugin:
       name: nyl
       env:
+        - name: NYL_CMP_TEMPLATE_INPUT
+          value: nginx.yaml
         - name: NYL_RELEASE_NAME
           value: nginx
         - name: NYL_RELEASE_NAMESPACE

--- a/nyl/book/src/argocd/application-generator.md
+++ b/nyl/book/src/argocd/application-generator.md
@@ -361,7 +361,7 @@ spec:
     path: clusters/default       # Directory of the file
     targetRevision: HEAD         # From generator.spec.source.targetRevision
     plugin:
-      name: nyl
+      name: nyl-v2
       env:
         - name: NYL_CMP_TEMPLATE_INPUT
           value: nginx.yaml

--- a/nyl/book/src/argocd/bootstrapping.md
+++ b/nyl/book/src/argocd/bootstrapping.md
@@ -122,7 +122,7 @@ spec:
     configs:
       cm:
         configManagementPlugins: |
-          - name: nyl
+          - name: nyl-v2
             generate:
               command: ["/bin/sh", "-c"]
               args:
@@ -262,7 +262,7 @@ spec:
     targetRevision: HEAD
     path: argocd
     plugin:
-      name: nyl
+      name: nyl-v2
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd
@@ -288,7 +288,7 @@ spec:
     targetRevision: HEAD
     path: .
     plugin:
-      name: nyl
+      name: nyl-v2
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd

--- a/nyl/book/src/argocd/bootstrapping.md
+++ b/nyl/book/src/argocd/bootstrapping.md
@@ -126,7 +126,10 @@ spec:
             generate:
               command: ["/bin/sh", "-c"]
               args:
-                - nyl render .
+                - |
+                  TEMPLATE_INPUT="${ARGOCD_ENV_NYL_CMP_TEMPLATE_INPUT:-${NYL_CMP_TEMPLATE_INPUT:-}}"
+                  test -n "$TEMPLATE_INPUT" || { echo "NYL_CMP_TEMPLATE_INPUT is required" >&2; exit 1; }
+                  nyl render "$TEMPLATE_INPUT"
 ```
 
 ## Step 3: Create ApplicationGenerator
@@ -352,7 +355,7 @@ When you apply `bootstrap.yaml`:
 
 1. **ArgoCD Namespace Created**: The `argocd` namespace is created
 2. **ArgoCD Application Syncs**: ArgoCD installs itself via the Nyl plugin
-3. **Apps Application Syncs**: The "apps" Application runs `nyl render .`
+3. **Apps Application Syncs**: The "apps" Application runs `nyl render "$NYL_CMP_TEMPLATE_INPUT"` (for example `apps.yaml`)
 4. **ApplicationGenerator Processes**: Nyl finds `apps.yaml`, sees ApplicationGenerator
 5. **Directory Scanned**: Nyl scans `clusters/default/` for YAML files
 6. **Applications Generated**: For each NylRelease found (nginx, redis), Nyl generates an ArgoCD Application

--- a/nyl/book/src/argocd/plugin.md
+++ b/nyl/book/src/argocd/plugin.md
@@ -85,7 +85,7 @@ metadata:
   namespace: argocd
 data:
   configManagementPlugins: |
-    - name: nyl
+    - name: nyl-v2
       generate:
         command: ["/bin/sh", "-c"]
         args:
@@ -114,7 +114,7 @@ spec:
     targetRevision: HEAD
     path: path/to/nyl/manifests
     plugin:
-      name: nyl
+      name: nyl-v2
   destination:
     server: https://kubernetes.default.svc
     namespace: default
@@ -140,7 +140,7 @@ You can pass environment variables to the Nyl plugin for configuration:
 ```yaml
 source:
   plugin:
-    name: nyl
+    name: nyl-v2
     env:
     - name: NYL_CMP_TEMPLATE_INPUT
       value: apps.yaml
@@ -156,7 +156,7 @@ source:
 
 If ArgoCD reports "plugin not found", check:
 
-1. The plugin name matches exactly: `nyl`
+1. The plugin name matches exactly: `nyl-v2`
 2. The argocd-cm ConfigMap is in the `argocd` namespace
 3. The repo-server pods have been restarted after configuration changes
 

--- a/nyl/book/src/argocd/plugin.md
+++ b/nyl/book/src/argocd/plugin.md
@@ -90,8 +90,9 @@ data:
         command: ["/bin/sh", "-c"]
         args:
         - |
-          # Render manifests with Nyl
-          nyl render .
+          TEMPLATE_INPUT="${ARGOCD_ENV_NYL_CMP_TEMPLATE_INPUT:-${NYL_CMP_TEMPLATE_INPUT:-}}"
+          test -n "$TEMPLATE_INPUT" || { echo "NYL_CMP_TEMPLATE_INPUT is required" >&2; exit 1; }
+          nyl render "$TEMPLATE_INPUT"
 ```
 
 ## Verification
@@ -141,6 +142,8 @@ source:
   plugin:
     name: nyl
     env:
+    - name: NYL_CMP_TEMPLATE_INPUT
+      value: apps.yaml
     - name: NYL_RELEASE_NAME
       value: my-app
     - name: NYL_RELEASE_NAMESPACE

--- a/nyl/book/src/reference/resources/nyl-release.md
+++ b/nyl/book/src/reference/resources/nyl-release.md
@@ -156,7 +156,7 @@ kind: Application
 spec:
   source:
     plugin:
-      name: nyl
+      name: nyl-v2
       env:
         - name: NYL_RELEASE_NAME
           value: myapp          # From NylRelease.metadata.name

--- a/nyl/src/cli/commands/generate.rs
+++ b/nyl/src/cli/commands/generate.rs
@@ -166,11 +166,7 @@ fn create_argocd_application(
     // Calculate relative path from base_dir
     let base_path = std::fs::canonicalize(base_dir)?;
     let file_abs = std::fs::canonicalize(file_path)?;
-    let rel_path = file_abs
-        .strip_prefix(&base_path)
-        .unwrap_or(file_path)
-        .to_str()
-        .ok_or_else(|| NylError::Config("Invalid file path encoding".to_string()))?;
+    let rel_path = normalize_relative_path_to_posix(file_abs.strip_prefix(&base_path).unwrap_or(file_path));
 
     Ok(serde_json::json!({
         "apiVersion": "argoproj.io/v1alpha1",
@@ -196,6 +192,10 @@ fn create_argocd_application(
                             "name": "NYL_RELEASE_NAMESPACE",
                             "value": release.metadata.namespace,
                         },
+                        {
+                            "name": "NYL_CMP_TEMPLATE_INPUT",
+                            "value": rel_path,
+                        },
                     ],
                 },
             },
@@ -211,6 +211,20 @@ fn create_argocd_application(
             },
         },
     }))
+}
+
+/// Normalize a relative path to POSIX-style separators.
+fn normalize_relative_path_to_posix(path: &Path) -> String {
+    let mut normalized = String::new();
+    for component in path.components() {
+        if let std::path::Component::Normal(os_str) = component {
+            if !normalized.is_empty() {
+                normalized.push('/');
+            }
+            normalized.push_str(&os_str.to_string_lossy());
+        }
+    }
+    normalized
 }
 
 /// Find all YAML files in a directory (recursively)
@@ -310,5 +324,13 @@ metadata:
         assert_eq!(app["spec"]["source"]["repoURL"], "https://github.com/example/repo");
         assert_eq!(app["spec"]["destination"]["namespace"], "production");
         assert_eq!(app["spec"]["source"]["path"], "test-manifest.yaml");
+
+        let env = app["spec"]["source"]["plugin"]["env"].as_array().unwrap();
+        let template_input = env
+            .iter()
+            .find(|v| v["name"] == "NYL_CMP_TEMPLATE_INPUT")
+            .and_then(|v| v["value"].as_str())
+            .unwrap();
+        assert_eq!(template_input, "test-manifest.yaml");
     }
 }

--- a/nyl/src/cli/commands/generate.rs
+++ b/nyl/src/cli/commands/generate.rs
@@ -182,7 +182,7 @@ fn create_argocd_application(
                 "path": rel_path,
                 "targetRevision": revision,
                 "plugin": {
-                    "name": "nyl",
+                    "name": "nyl-v2",
                     "env": [
                         {
                             "name": "NYL_RELEASE_NAME",
@@ -324,6 +324,7 @@ metadata:
         assert_eq!(app["spec"]["source"]["repoURL"], "https://github.com/example/repo");
         assert_eq!(app["spec"]["destination"]["namespace"], "production");
         assert_eq!(app["spec"]["source"]["path"], "test-manifest.yaml");
+        assert_eq!(app["spec"]["source"]["plugin"]["name"], "nyl-v2");
 
         let env = app["spec"]["source"]["plugin"]["env"].as_array().unwrap();
         let template_input = env

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -939,15 +939,11 @@ fn create_argocd_application_from_generator(
         .unwrap_or(Path::new(""));
 
     // Normalize the relative directory to POSIX-style separators for ArgoCD.
-    let mut rel_dir_normalized = String::new();
-    for component in rel_dir.components() {
-        if let std::path::Component::Normal(os_str) = component {
-            if !rel_dir_normalized.is_empty() {
-                rel_dir_normalized.push('/');
-            }
-            rel_dir_normalized.push_str(&os_str.to_string_lossy());
-        }
-    }
+    let rel_dir_normalized = normalize_relative_path_to_posix(rel_dir);
+    let template_input = file_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| NylError::Config(format!("Invalid file name: {}", file_path.display())))?;
 
     // Application path must be relative to the repo root, not the worktree.
     // Start from the generator's source.path and append any subdirectory.
@@ -976,6 +972,7 @@ fn create_argocd_application_from_generator(
                     "env": [
                         {"name": "NYL_RELEASE_NAME", "value": release.metadata.name},
                         {"name": "NYL_RELEASE_NAMESPACE", "value": release.metadata.namespace},
+                        {"name": "NYL_CMP_TEMPLATE_INPUT", "value": template_input},
                     ],
                 },
             },
@@ -1002,6 +999,20 @@ fn create_argocd_application_from_generator(
     }
 
     Ok(app)
+}
+
+/// Normalize a relative path to POSIX-style separators.
+fn normalize_relative_path_to_posix(path: &Path) -> String {
+    let mut normalized = String::new();
+    for component in path.components() {
+        if let std::path::Component::Normal(os_str) = component {
+            if !normalized.is_empty() {
+                normalized.push('/');
+            }
+            normalized.push_str(&os_str.to_string_lossy());
+        }
+    }
+    normalized
 }
 
 /// Add parent resource tracking annotations to a manifest
@@ -1137,21 +1148,72 @@ metadata:
     }
 
     #[test]
+    fn test_create_argocd_application_from_generator_sets_template_input() {
+        use crate::resources::{
+            ApplicationDestination, ApplicationGenerator, ApplicationGeneratorMetadata, ApplicationGeneratorSpec,
+            ApplicationSource, NylReleaseMetadata, NylReleaseSpec,
+        };
+        use std::collections::HashMap;
+        use std::path::Path;
+
+        let release = NylRelease {
+            api_version: API_VERSION.to_string(),
+            kind: "NylRelease".to_string(),
+            metadata: NylReleaseMetadata {
+                name: "nginx".to_string(),
+                namespace: "web".to_string(),
+            },
+            spec: NylReleaseSpec::default(),
+        };
+
+        let generator = ApplicationGenerator {
+            api_version: API_VERSION_ARGOCD.to_string(),
+            kind: "ApplicationGenerator".to_string(),
+            metadata: ApplicationGeneratorMetadata {
+                name: "apps".to_string(),
+                namespace: Some("argocd".to_string()),
+            },
+            spec: ApplicationGeneratorSpec {
+                destination: ApplicationDestination {
+                    server: "https://kubernetes.default.svc".to_string(),
+                    namespace: "argocd".to_string(),
+                },
+                source: ApplicationSource {
+                    repo_url: "https://github.com/example/repo.git".to_string(),
+                    target_revision: "HEAD".to_string(),
+                    path: "clusters/default".to_string(),
+                    include: vec!["*.yaml".to_string()],
+                    exclude: vec![".*".to_string()],
+                },
+                project: "default".to_string(),
+                sync_policy: None,
+                application_name_template: "{{ .release.name }}".to_string(),
+                labels: HashMap::new(),
+                annotations: HashMap::new(),
+            },
+        };
+
+        let file_path = Path::new("/tmp/worktree/clusters/default/addons/nginx.yaml");
+        let base_path = Path::new("/tmp/worktree/clusters/default");
+        let app = create_argocd_application_from_generator(&release, file_path, base_path, &generator).unwrap();
+
+        assert_eq!(app["spec"]["source"]["path"], "clusters/default/addons");
+
+        let env = app["spec"]["source"]["plugin"]["env"].as_array().unwrap();
+        let template_input = env
+            .iter()
+            .find(|v| v["name"] == "NYL_CMP_TEMPLATE_INPUT")
+            .and_then(|v| v["value"].as_str())
+            .unwrap();
+        assert_eq!(template_input, "nginx.yaml");
+    }
+
+    #[test]
     fn test_path_normalization_posix() {
         use std::path::Path;
 
-        // Simulate the path normalization logic in create_argocd_application_from_generator
         let rel_dir = Path::new("subdir/nested");
-        let mut rel_dir_normalized = String::new();
-        for component in rel_dir.components() {
-            if let std::path::Component::Normal(os_str) = component {
-                if !rel_dir_normalized.is_empty() {
-                    rel_dir_normalized.push('/');
-                }
-                rel_dir_normalized.push_str(&os_str.to_string_lossy());
-            }
-        }
-
+        let rel_dir_normalized = normalize_relative_path_to_posix(rel_dir);
         assert_eq!(rel_dir_normalized, "subdir/nested");
     }
 
@@ -1161,15 +1223,7 @@ metadata:
 
         // Test with platform-native path construction
         let rel_dir = Path::new("subdir").join("nested");
-        let mut rel_dir_normalized = String::new();
-        for component in rel_dir.components() {
-            if let std::path::Component::Normal(os_str) = component {
-                if !rel_dir_normalized.is_empty() {
-                    rel_dir_normalized.push('/');
-                }
-                rel_dir_normalized.push_str(&os_str.to_string_lossy());
-            }
-        }
+        let rel_dir_normalized = normalize_relative_path_to_posix(&rel_dir);
 
         // Should always produce POSIX-style paths regardless of platform
         assert_eq!(rel_dir_normalized, "subdir/nested");
@@ -1181,15 +1235,7 @@ metadata:
 
         // Test empty path handling
         let rel_dir = Path::new("");
-        let mut rel_dir_normalized = String::new();
-        for component in rel_dir.components() {
-            if let std::path::Component::Normal(os_str) = component {
-                if !rel_dir_normalized.is_empty() {
-                    rel_dir_normalized.push('/');
-                }
-                rel_dir_normalized.push_str(&os_str.to_string_lossy());
-            }
-        }
+        let rel_dir_normalized = normalize_relative_path_to_posix(rel_dir);
 
         assert_eq!(rel_dir_normalized, "");
     }

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -1,11 +1,11 @@
 use clap::Args;
 use std::path::Path;
+use std::sync::Arc;
 use walkdir::WalkDir;
 
 use crate::{
     config::ProjectConfig,
     constants::{API_VERSION, API_VERSION_ARGOCD, API_VERSION_COMPONENTS},
-    generator::Generator,
     helm::{HelmChartResolver, HelmTemplateExecutor},
     kubernetes::{KubeClient, KubeRsClient, ResourceKey},
     postprocess::apply_kyverno_policies,
@@ -106,7 +106,7 @@ pub async fn render_manifests_complete(
     std::collections::HashMap<ResourceKey, usize>,
 )> {
     // 1. Render manifests (base pipeline)
-    let (manifests, profile, env_name) = render_manifests(
+    let (manifests, profile, env_name, credential_provider) = render_manifests(
         path,
         only_source_kind,
         environment,
@@ -124,7 +124,7 @@ pub async fn render_manifests_complete(
     // 3. Extract ApplicationGenerator resources and replace with ArgoCD Applications
     let (generators, mut final_manifests) = extract_application_generators(&manifests)?;
     for generator in generators {
-        let applications = process_application_generator(&generator, path)?;
+        let applications = process_application_generator(&generator, path, credential_provider.clone())?;
         final_manifests.extend(applications);
     }
 
@@ -173,7 +173,12 @@ pub async fn render_manifests(
     cli_api_versions: &[String],
     max_depth: usize,
     track_parent: bool,
-) -> Result<(Vec<serde_json::Value>, Profile, String)> {
+) -> Result<(
+    Vec<serde_json::Value>,
+    Profile,
+    String,
+    Option<Arc<crate::git::CredentialProvider>>,
+)> {
     // 1. Load project configuration (with warning if not found)
     let project_config = ProjectConfig::load_with_warning(None)?;
 
@@ -213,8 +218,9 @@ pub async fn render_manifests(
     // 4. Build template context
     let context = TemplateContext::build(&profile, &secrets_config, &env_name)?;
 
+    let credential_provider = crate::git::argocd_credential_provider_from_cluster().await;
+
     // 5. Create generator
-    let generator = Generator::new(project_config.clone());
 
     // 6. Load and filter resources (rendering Jinja templates in manifest files)
     let resources = load_resources(path, &context)?;
@@ -260,12 +266,12 @@ pub async fn render_manifests(
         let mut next_pending = Vec::new();
         for resource in pending {
             let manifests = generate_resource(
-                &generator,
                 &resource,
                 &context,
                 &project_config,
                 &kube_version,
                 &api_versions,
+                credential_provider.clone(),
                 track_parent,
             )?;
             for manifest in manifests {
@@ -286,7 +292,7 @@ pub async fn render_manifests(
     // This happens when max_depth is reached before all resources are expanded
     all_manifests.extend(pending);
 
-    Ok((all_manifests, profile, env_name))
+    Ok((all_manifests, profile, env_name, credential_provider))
 }
 
 pub async fn execute(args: RenderArgs) -> Result<()> {
@@ -548,12 +554,12 @@ fn is_known_nyl_resource(resource: &serde_json::Value) -> bool {
 /// Generate manifests from a resource
 #[allow(clippy::too_many_lines)]
 fn generate_resource(
-    _generator: &Generator,
     resource: &serde_json::Value,
     context: &TemplateContext,
     config: &ProjectConfig,
     kube_version: &str,
     api_versions: &[String],
+    credential_provider: Option<Arc<crate::git::CredentialProvider>>,
     track_parent: bool,
 ) -> Result<Vec<serde_json::Value>> {
     // Check if it's a HelmChart resource
@@ -564,7 +570,14 @@ fn generate_resource(
         // Parse as HelmChart and render
         let chart: HelmChart = serde_json::from_value(resource.clone())
             .map_err(|e| NylError::Config(format!("Failed to parse HelmChart: {}", e)))?;
-        let manifests = render_helm_chart(&chart, context, config, kube_version, api_versions)?;
+        let manifests = render_helm_chart(
+            &chart,
+            context,
+            config,
+            kube_version,
+            api_versions,
+            credential_provider.clone(),
+        )?;
 
         // Add parent tracking annotations if enabled
         if track_parent {
@@ -620,7 +633,14 @@ fn generate_resource(
                 },
             };
 
-            let manifests = render_helm_chart(&chart, context, config, kube_version, api_versions)?;
+            let manifests = render_helm_chart(
+                &chart,
+                context,
+                config,
+                kube_version,
+                api_versions,
+                credential_provider.clone(),
+            )?;
 
             // Add parent tracking annotations if enabled
             if track_parent {
@@ -671,7 +691,14 @@ fn generate_resource(
                 },
             };
 
-            let manifests = render_helm_chart(&chart, context, config, kube_version, api_versions)?;
+            let manifests = render_helm_chart(
+                &chart,
+                context,
+                config,
+                kube_version,
+                api_versions,
+                credential_provider.clone(),
+            )?;
 
             // Add parent tracking annotations if enabled
             if track_parent {
@@ -730,11 +757,17 @@ fn render_helm_chart(
     config: &ProjectConfig,
     kube_version: &str,
     api_versions: &[String],
+    credential_provider: Option<Arc<crate::git::CredentialProvider>>,
 ) -> Result<Vec<serde_json::Value>> {
     let working_dir =
         std::env::current_dir().map_err(|e| NylError::Config(format!("Failed to get current directory: {}", e)))?;
 
-    let resolver = HelmChartResolver::new(config.config.settings.search_path.clone(), working_dir);
+    let resolver = HelmChartResolver::with_cache_dir_and_provider(
+        config.config.settings.search_path.clone(),
+        working_dir,
+        None,
+        credential_provider,
+    );
     let resolved = resolver.resolve_chart(&chart.spec.chart)?;
 
     // Merge context values into chart values
@@ -775,9 +808,10 @@ fn output_manifests(manifests: &[serde_json::Value], format: OutputFormat) -> Re
 fn process_application_generator(
     generator: &crate::resources::ApplicationGenerator,
     _base_dir: &str,
+    credential_provider: Option<Arc<crate::git::CredentialProvider>>,
 ) -> Result<Vec<serde_json::Value>> {
     // Clone Git repository and resolve to local path
-    let mut git_manager = crate::git::GitManager::new()?;
+    let mut git_manager = crate::git::GitManager::with_credential_provider(credential_provider)?;
 
     let source_path = git_manager.resolve_ref(
         &generator.spec.source.repo_url,

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -968,7 +968,7 @@ fn create_argocd_application_from_generator(
                 "path": path_str,
                 "targetRevision": generator.spec.source.target_revision,
                 "plugin": {
-                    "name": "nyl",
+                    "name": "nyl-v2",
                     "env": [
                         {"name": "NYL_RELEASE_NAME", "value": release.metadata.name},
                         {"name": "NYL_RELEASE_NAMESPACE", "value": release.metadata.namespace},
@@ -1198,6 +1198,7 @@ metadata:
         let app = create_argocd_application_from_generator(&release, file_path, base_path, &generator).unwrap();
 
         assert_eq!(app["spec"]["source"]["path"], "clusters/default/addons");
+        assert_eq!(app["spec"]["source"]["plugin"]["name"], "nyl-v2");
 
         let env = app["spec"]["source"]["plugin"]["env"].as_array().unwrap();
         let template_input = env

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -123,8 +123,20 @@ pub async fn render_manifests_complete(
 
     // 3. Extract ApplicationGenerator resources and replace with ArgoCD Applications
     let (generators, mut final_manifests) = extract_application_generators(&manifests)?;
+    if !generators.is_empty() {
+        tracing::debug!(
+            "Found {} ApplicationGenerator resource(s) in {}",
+            generators.len(),
+            path
+        );
+    }
     for generator in generators {
         let applications = process_application_generator(&generator, path, credential_provider.clone())?;
+        tracing::debug!(
+            "ApplicationGenerator {} produced {} ArgoCD Application(s)",
+            generator.metadata.name,
+            applications.len()
+        );
         final_manifests.extend(applications);
     }
 
@@ -810,6 +822,14 @@ fn process_application_generator(
     _base_dir: &str,
     credential_provider: Option<Arc<crate::git::CredentialProvider>>,
 ) -> Result<Vec<serde_json::Value>> {
+    tracing::debug!(
+        "Processing ApplicationGenerator {}: repoURL={}, targetRevision={}, source.path={}",
+        generator.metadata.name,
+        generator.spec.source.repo_url,
+        generator.spec.source.target_revision,
+        generator.spec.source.path
+    );
+
     // Clone Git repository and resolve to local path
     let mut git_manager = crate::git::GitManager::with_credential_provider(credential_provider)?;
 
@@ -818,6 +838,11 @@ fn process_application_generator(
         Some(&generator.spec.source.target_revision),
         Some(&generator.spec.source.path),
     )?;
+    tracing::debug!(
+        "ApplicationGenerator {} resolved source path to {}",
+        generator.metadata.name,
+        source_path.display()
+    );
 
     // Find YAML files matching filters
     let yaml_files = find_yaml_files_filtered(
@@ -825,6 +850,11 @@ fn process_application_generator(
         &generator.spec.source.include,
         &generator.spec.source.exclude,
     )?;
+    tracing::debug!(
+        "ApplicationGenerator {} discovered {} YAML file(s) after include/exclude filters",
+        generator.metadata.name,
+        yaml_files.len()
+    );
 
     let mut applications = Vec::new();
 
@@ -843,11 +873,22 @@ fn process_application_generator(
         if let Some(release) = nyl_release {
             // Generate ArgoCD Application
             let app = create_argocd_application_from_generator(&release, &file_path, &source_path, generator)?;
+            tracing::debug!(
+                "Generated ArgoCD Application {} from NylRelease in {}",
+                release.metadata.name,
+                file_path.display()
+            );
             applications.push(app);
+        } else {
+            tracing::trace!("No NylRelease found in {}, skipping", file_path.display());
         }
-        // Skip files without NylRelease (no warning to avoid noise)
     }
 
+    tracing::debug!(
+        "ApplicationGenerator {} generated {} ArgoCD Application(s) total",
+        generator.metadata.name,
+        applications.len()
+    );
     Ok(applications)
 }
 

--- a/nyl/src/git/argocd.rs
+++ b/nyl/src/git/argocd.rs
@@ -11,19 +11,51 @@ use std::sync::{Arc, Mutex};
 use super::auth::GitCredential;
 use super::error::{GitError, Result};
 
+/// Path to the service account namespace file in a Kubernetes pod
+const SERVICE_ACCOUNT_NAMESPACE_PATH: &str = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+
+/// Default namespace for ArgoCD installation
+const DEFAULT_ARGOCD_NAMESPACE: &str = "argocd";
+
 /// ArgoCD credential discovery from Kubernetes secrets
 pub struct ArgoCDCredentialDiscovery {
     client: Client,
+    namespace: String,
     secret_cache: Arc<Mutex<HashMap<String, Secret>>>,
 }
 
 impl ArgoCDCredentialDiscovery {
     /// Create a new ArgoCD credential discovery client
+    ///
+    /// If `namespace` is None, attempts to detect the namespace from the pod's service account.
+    /// Falls back to "argocd" if detection fails.
     pub fn new(client: Client) -> Result<Self> {
+        let namespace = Self::detect_namespace().unwrap_or_else(|| DEFAULT_ARGOCD_NAMESPACE.to_string());
+        tracing::debug!("Using namespace '{}' for ArgoCD credential discovery", namespace);
+
         Ok(Self {
             client,
+            namespace,
             secret_cache: Arc::new(Mutex::new(HashMap::new())),
         })
+    }
+
+    /// Create a new ArgoCD credential discovery client with an explicit namespace
+    pub fn with_namespace(client: Client, namespace: String) -> Result<Self> {
+        Ok(Self {
+            client,
+            namespace,
+            secret_cache: Arc::new(Mutex::new(HashMap::new())),
+        })
+    }
+
+    /// Detect the current namespace from the pod's service account
+    ///
+    /// Reads from the service account namespace file mounted in Kubernetes pods
+    fn detect_namespace() -> Option<String> {
+        std::fs::read_to_string(SERVICE_ACCOUNT_NAMESPACE_PATH)
+            .ok()
+            .map(|ns| ns.trim().to_string())
     }
 
     /// Discover all credentials from ArgoCD repository secrets
@@ -112,7 +144,7 @@ impl ArgoCDCredentialDiscovery {
             }
         }
 
-        let secrets_api: Api<Secret> = Api::namespaced(self.client.clone(), "argocd");
+        let secrets_api: Api<Secret> = Api::namespaced(self.client.clone(), &self.namespace);
 
         // Query repository secrets
         let repo_lp = kube::api::ListParams::default().labels("argocd.argoproj.io/secret-type=repository");

--- a/nyl/src/git/argocd.rs
+++ b/nyl/src/git/argocd.rs
@@ -61,6 +61,11 @@ impl ArgoCDCredentialDiscovery {
     /// Discover all credentials from ArgoCD repository secrets
     pub async fn discover_credentials(&self) -> Result<HashMap<String, GitCredential>> {
         let secrets = self.query_repository_secrets().await?;
+        tracing::debug!(
+            "Discovered {} ArgoCD repository secret candidates in namespace {}",
+            secrets.len(),
+            self.namespace
+        );
         let mut credentials = HashMap::new();
 
         for (name, secret) in secrets {
@@ -79,6 +84,11 @@ impl ArgoCDCredentialDiscovery {
             }
         }
 
+        tracing::debug!(
+            "Extracted {} usable Git credentials from ArgoCD secrets in namespace {}",
+            credentials.len(),
+            self.namespace
+        );
         Ok(credentials)
     }
 
@@ -152,6 +162,11 @@ impl ArgoCDCredentialDiscovery {
             .list(&repo_lp)
             .await
             .map_err(|e| GitError::ArgoCDSecretQueryFailed(e.to_string()))?;
+        tracing::trace!(
+            "Found {} secrets labeled repository in namespace {}",
+            repo_secrets.items.len(),
+            self.namespace
+        );
 
         // Query repo-creds secrets
         let creds_lp = kube::api::ListParams::default().labels("argocd.argoproj.io/secret-type=repo-creds");
@@ -159,6 +174,11 @@ impl ArgoCDCredentialDiscovery {
             .list(&creds_lp)
             .await
             .map_err(|e| GitError::ArgoCDSecretQueryFailed(e.to_string()))?;
+        tracing::trace!(
+            "Found {} secrets labeled repo-creds in namespace {}",
+            creds_secrets.items.len(),
+            self.namespace
+        );
 
         // Combine both sets of secrets, filtering for type="git" only
         let mut secrets = HashMap::new();

--- a/nyl/src/git/auth.rs
+++ b/nyl/src/git/auth.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 /// Git credential types for authentication
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum GitCredential {
     /// SSH key authentication
     SshKey {
@@ -24,6 +24,27 @@ pub enum GitCredential {
     },
     /// SSH agent authentication (use SSH agent for key)
     SshAgent { username: String },
+}
+
+// Custom Debug implementation that redacts sensitive data
+impl std::fmt::Debug for GitCredential {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GitCredential::SshKey { username, .. } => f
+                .debug_struct("SshKey")
+                .field("username", username)
+                .field("private_key", &"<redacted>")
+                .field("public_key", &"<redacted>")
+                .field("passphrase", &"<redacted>")
+                .finish(),
+            GitCredential::HttpsToken { username, .. } => f
+                .debug_struct("HttpsToken")
+                .field("username", username)
+                .field("token", &"<redacted>")
+                .finish(),
+            GitCredential::SshAgent { username } => f.debug_struct("SshAgent").field("username", username).finish(),
+        }
+    }
 }
 
 impl GitCredential {
@@ -49,9 +70,19 @@ impl GitCredential {
 }
 
 /// Provides credentials for Git operations
-#[derive(Debug)]
 pub struct CredentialProvider {
     credentials: Arc<Mutex<HashMap<String, GitCredential>>>,
+}
+
+// Custom Debug implementation that doesn't expose credential values
+impl std::fmt::Debug for CredentialProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let creds = self.credentials.lock().unwrap();
+        f.debug_struct("CredentialProvider")
+            .field("credential_count", &creds.len())
+            .field("urls", &creds.keys().collect::<Vec<_>>())
+            .finish()
+    }
 }
 
 impl CredentialProvider {

--- a/nyl/src/git/auth.rs
+++ b/nyl/src/git/auth.rs
@@ -49,6 +49,7 @@ impl GitCredential {
 }
 
 /// Provides credentials for Git operations
+#[derive(Debug)]
 pub struct CredentialProvider {
     credentials: Arc<Mutex<HashMap<String, GitCredential>>>,
 }

--- a/nyl/src/git/auth.rs
+++ b/nyl/src/git/auth.rs
@@ -112,6 +112,11 @@ impl CredentialProvider {
 
         // Try exact match first
         if let Some(cred) = creds.get(url) {
+            tracing::debug!(
+                "Matched Git credential via exact URL for {} (type={})",
+                url,
+                Self::credential_kind(cred)
+            );
             return Some(cred.clone());
         }
 
@@ -121,12 +126,19 @@ impl CredentialProvider {
             for (stored_url, credential) in creds.iter() {
                 if let Some(stored_host) = extract_hostname(stored_url) {
                     if host == stored_host {
+                        tracing::debug!(
+                            "Matched Git credential via hostname fallback for {} using stored URL {} (type={})",
+                            url,
+                            stored_url,
+                            Self::credential_kind(credential)
+                        );
                         return Some(credential.clone());
                     }
                 }
             }
         }
 
+        tracing::debug!("No stored Git credential matched URL {}", url);
         None
     }
 
@@ -138,6 +150,12 @@ impl CredentialProvider {
         callbacks.credentials(move |url, username_from_url, allowed_types| {
             // If we have a stored credential, use it
             if let Some(ref cred) = credential {
+                tracing::trace!(
+                    "Using stored Git credential for {} (type={}, username_from_url={})",
+                    url,
+                    Self::credential_kind(cred),
+                    username_from_url.unwrap_or("<none>")
+                );
                 return cred.to_git2_cred(url, username_from_url);
             }
 
@@ -145,15 +163,25 @@ impl CredentialProvider {
             if allowed_types.contains(CredentialType::SSH_KEY) {
                 let username = username_from_url.unwrap_or("git");
                 if let Ok(cred) = Cred::ssh_key_from_agent(username) {
+                    tracing::trace!("Using SSH agent fallback for {} as {}", url, username);
                     return Ok(cred);
                 }
             }
 
             // No credential available
+            tracing::trace!("No Git credentials available for {}", url);
             Err(git2::Error::from_str("No credentials available"))
         });
 
         callbacks
+    }
+
+    fn credential_kind(credential: &GitCredential) -> &'static str {
+        match credential {
+            GitCredential::SshKey { .. } => "ssh-key",
+            GitCredential::HttpsToken { .. } => "https-token",
+            GitCredential::SshAgent { .. } => "ssh-agent",
+        }
     }
 }
 

--- a/nyl/src/git/error.rs
+++ b/nyl/src/git/error.rs
@@ -16,6 +16,15 @@ pub enum GitError {
     #[error("Reference '{ref_name}' not found in repository\nHint: Check that the branch, tag, or commit exists. Use 'git ls-remote <url>' to list available refs.")]
     RefNotFound { ref_name: String },
 
+    #[error(
+        "Failed to fetch refs for {url}, and no cached ref '{ref_name}' was available: {fetch_error}\nHint: Verify repository credentials and network access, or use a resolvable targetRevision."
+    )]
+    FetchFailedNoCachedRef {
+        url: String,
+        ref_name: String,
+        fetch_error: String,
+    },
+
     #[error("Worktree operation failed: {0}\nHint: Ensure the worktree directory is writable and not already in use.")]
     WorktreeFailed(String),
 
@@ -127,6 +136,16 @@ mod tests {
         let display = format!("{}", ref_err);
         assert!(display.contains("Hint:"));
         assert!(display.contains("git ls-remote"));
+
+        let fetch_cache_err = GitError::FetchFailedNoCachedRef {
+            url: "https://github.com/user/repo.git".to_string(),
+            ref_name: "HEAD".to_string(),
+            fetch_error: "git fetch failed: auth".to_string(),
+        };
+        let display = format!("{}", fetch_cache_err);
+        assert!(display.contains("Hint:"));
+        assert!(display.contains("credentials"));
+        assert!(display.contains("HEAD"));
     }
 
     #[test]

--- a/nyl/src/git/mod.rs
+++ b/nyl/src/git/mod.rs
@@ -64,10 +64,13 @@ fn is_argocd_env() -> bool {
 
 pub async fn argocd_credential_provider_from_cluster() -> Option<Arc<CredentialProvider>> {
     if !is_argocd_env() {
+        tracing::trace!("Not running in ArgoCD environment; skipping credential discovery");
         return None;
     }
+    tracing::debug!("ArgoCD environment detected, attempting credential discovery from cluster");
 
     let Ok(config) = kube::Config::incluster_env() else {
+        tracing::debug!("In-cluster Kubernetes config not available; skipping ArgoCD credential discovery");
         return None;
     };
 
@@ -90,8 +93,10 @@ pub async fn argocd_credential_provider_from_cluster() -> Option<Arc<CredentialP
     match discovery.discover_credentials().await {
         Ok(credentials) => {
             if credentials.is_empty() {
+                tracing::debug!("No ArgoCD Git credentials discovered");
                 return None;
             }
+            tracing::debug!("Loaded {} ArgoCD Git credentials", credentials.len());
             Some(Arc::new(CredentialProvider::with_credentials(credentials)))
         }
         Err(e) => {
@@ -199,17 +204,42 @@ impl GitManager {
 
         // Always fetch latest refs to ensure we have the most recent version
         // Fall back to cached refs if fetch fails (e.g., offline scenarios)
-        {
+        let fetch_error = {
             let repo = bare_repo.lock().unwrap();
             if let Err(e) = repo.fetch_refs() {
                 tracing::warn!("Failed to fetch refs for {}: {}. Falling back to cached refs.", url, e);
+                Some(e)
+            } else {
+                None
             }
-        }
+        };
 
         // Resolve ref to OID
         let oid = {
             let repo = bare_repo.lock().unwrap();
-            repo.resolve_ref(git_ref)?
+            match repo.resolve_ref(git_ref) {
+                Ok(oid) => {
+                    if fetch_error.is_some() {
+                        tracing::debug!("Using cached ref '{}' for {} after fetch failure", git_ref, url);
+                    }
+                    oid
+                }
+                Err(resolve_error) => {
+                    if let Some(fetch_error) = &fetch_error {
+                        tracing::warn!(
+                            "Fetch fallback unavailable for {} at ref '{}': no cached ref found after fetch failure",
+                            url,
+                            git_ref
+                        );
+                        return Err(GitError::FetchFailedNoCachedRef {
+                            url: url.to_string(),
+                            ref_name: git_ref.to_string(),
+                            fetch_error: fetch_error.to_string(),
+                        });
+                    }
+                    return Err(resolve_error);
+                }
+            }
         };
 
         // Check if we have the commit objects, fetch if needed
@@ -267,6 +297,9 @@ impl Default for GitManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use git2::Repository;
+    use repository::BareRepository;
+    use std::sync::{Arc, Mutex};
     use tempfile::TempDir;
 
     #[test]
@@ -276,5 +309,60 @@ mod tests {
         let manager = GitManager::with_cache_dir(temp_cache.path());
         // Verify it was created (with_cache_dir doesn't return Result)
         assert!(manager.bare_repos.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_ref_uses_cached_ref_when_fetch_fails() {
+        let source_dir = TempDir::new().unwrap();
+        let source_repo = Repository::init(source_dir.path()).unwrap();
+
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_id = {
+            let mut index = source_repo.index().unwrap();
+            index.write_tree().unwrap()
+        };
+        let tree = source_repo.find_tree(tree_id).unwrap();
+        source_repo
+            .commit(Some("HEAD"), &sig, &sig, "Initial commit", &tree, &[])
+            .unwrap();
+
+        let cache_dir = TempDir::new().unwrap();
+        let mut manager = GitManager::with_cache_dir(cache_dir.path());
+        let url = source_dir.path().to_string_lossy().to_string();
+
+        let first_path = manager.resolve_ref(&url, Some("HEAD"), None).unwrap();
+        assert!(first_path.exists());
+
+        std::fs::remove_dir_all(source_dir.path()).unwrap();
+
+        let second_path = manager.resolve_ref(&url, Some("HEAD"), None).unwrap();
+        assert!(second_path.exists());
+    }
+
+    #[test]
+    fn test_resolve_ref_errors_when_fetch_fails_and_no_cached_ref() {
+        let cache_dir = TempDir::new().unwrap();
+        let mut manager = GitManager::with_cache_dir(cache_dir.path());
+        let url = "/tmp/nyl-does-not-exist-cred-test".to_string();
+
+        let bare_repo_path = manager.cache.bare_repo_path(&url);
+        let raw_repo = Repository::init_bare(&bare_repo_path).unwrap();
+        raw_repo.remote("origin", &url).unwrap();
+        let bare_repo = BareRepository::get_or_create(&url, &bare_repo_path, None).unwrap();
+        manager.bare_repos.insert(url.clone(), Arc::new(Mutex::new(bare_repo)));
+
+        let err = manager.resolve_ref(&url, Some("HEAD"), None).unwrap_err();
+        match err {
+            GitError::FetchFailedNoCachedRef {
+                url: err_url,
+                ref_name,
+                fetch_error,
+            } => {
+                assert_eq!(err_url, url);
+                assert_eq!(ref_name, "HEAD");
+                assert!(fetch_error.contains("git fetch failed"));
+            }
+            other => panic!("Expected FetchFailedNoCachedRef, got {other:?}"),
+        }
     }
 }

--- a/nyl/src/git/mod.rs
+++ b/nyl/src/git/mod.rs
@@ -58,6 +58,49 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
+fn is_argocd_env() -> bool {
+    std::env::var_os("ARGOCD_APP_NAME").is_some() || std::env::var_os("ARGOCD_APP_NAMESPACE").is_some()
+}
+
+pub async fn argocd_credential_provider_from_cluster() -> Option<Arc<CredentialProvider>> {
+    if !is_argocd_env() {
+        return None;
+    }
+
+    let Ok(config) = kube::Config::incluster_env() else {
+        return None;
+    };
+
+    let client = match kube::Client::try_from(config) {
+        Ok(client) => client,
+        Err(e) => {
+            tracing::warn!("Failed to create in-cluster Kubernetes client: {}", e);
+            return None;
+        }
+    };
+
+    let discovery = match ArgoCDCredentialDiscovery::new(client) {
+        Ok(discovery) => discovery,
+        Err(e) => {
+            tracing::warn!("Failed to initialize ArgoCD credential discovery: {}", e);
+            return None;
+        }
+    };
+
+    match discovery.discover_credentials().await {
+        Ok(credentials) => {
+            if credentials.is_empty() {
+                return None;
+            }
+            Some(Arc::new(CredentialProvider::with_credentials(credentials)))
+        }
+        Err(e) => {
+            tracing::warn!("Failed to discover ArgoCD credentials: {}", e);
+            None
+        }
+    }
+}
+
 /// Main Git manager for resolving Git references to local paths
 pub struct GitManager {
     cache: CacheLayout,
@@ -80,10 +123,25 @@ impl GitManager {
     /// This is useful for testing where you want to avoid environment variable
     /// race conditions between parallel tests.
     pub fn with_cache_dir(cache_dir: impl Into<PathBuf>) -> Self {
+        Self::with_cache_dir_and_provider(cache_dir, None)
+    }
+
+    pub fn with_credential_provider(credential_provider: Option<Arc<CredentialProvider>>) -> Result<Self> {
+        Ok(Self {
+            cache: CacheLayout::new()?,
+            bare_repos: HashMap::new(),
+            credential_provider,
+        })
+    }
+
+    pub fn with_cache_dir_and_provider(
+        cache_dir: impl Into<PathBuf>,
+        credential_provider: Option<Arc<CredentialProvider>>,
+    ) -> Self {
         Self {
             cache: CacheLayout::with_path(cache_dir),
             bare_repos: HashMap::new(),
-            credential_provider: None,
+            credential_provider,
         }
     }
 

--- a/nyl/src/git/repository.rs
+++ b/nyl/src/git/repository.rs
@@ -16,8 +16,10 @@ impl BareRepository {
     /// Get or create a bare repository at the specified path
     pub fn get_or_create(url: &str, path: &Path, credential_provider: Option<Arc<CredentialProvider>>) -> Result<Self> {
         let repo = if path.exists() {
+            tracing::debug!("Reusing cached bare repository for {} at {}", url, path.display());
             Repository::open(path)?
         } else {
+            tracing::debug!("Creating bare repository cache for {} at {}", url, path.display());
             Self::clone_bare(url, path, credential_provider.as_deref())?
         };
 
@@ -35,6 +37,8 @@ impl BareRepository {
             std::fs::create_dir_all(parent)?;
         }
 
+        tracing::trace!("Starting bare clone for {} into {}", url, path.display());
+        tracing::debug!("Initializing bare Git repository for {} at {}", url, path.display());
         // Initialize bare repository
         let repo = Repository::init_bare(path).map_err(|e| GitError::CloneFailed {
             url: url.to_string(),
@@ -47,8 +51,11 @@ impl BareRepository {
             source: e,
         })?;
 
+        tracing::debug!("Fetching initial refs for {}", url);
         // Fetch refs only (no objects yet - lazy loading)
         Self::fetch_refs_with_auth(&repo, url, credential_provider)?;
+        tracing::debug!("Initial ref fetch complete for {}", url);
+        tracing::trace!("Bare clone completed successfully for {}", url);
 
         Ok(repo)
     }
@@ -59,6 +66,15 @@ impl BareRepository {
         url: &str,
         credential_provider: Option<&CredentialProvider>,
     ) -> Result<()> {
+        tracing::trace!(
+            "Fetching refs for {} (credential_provider={})",
+            url,
+            if credential_provider.is_some() {
+                "present"
+            } else {
+                "absent"
+            }
+        );
         let callbacks = if let Some(provider) = credential_provider {
             provider.build_callbacks(url)
         } else {
@@ -81,6 +97,7 @@ impl BareRepository {
             )
             .map_err(|e| GitError::Command(format!("git fetch failed: {}", e)))?;
 
+        tracing::trace!("Fetch refs completed for {}", url);
         Ok(())
     }
 
@@ -100,6 +117,7 @@ impl BareRepository {
 
     /// Update refs from the remote
     pub fn fetch_refs(&self) -> Result<()> {
+        tracing::debug!("Refreshing remote refs for {}", self.url);
         Self::fetch_refs_with_auth(&self.repo, &self.url, self.credential_provider.as_deref())
     }
 
@@ -166,6 +184,7 @@ impl BareRepository {
     /// Fetch specific objects for a commit
     pub fn fetch_objects(&self, oid: Oid) -> Result<()> {
         let oid_str = oid.to_string();
+        tracing::debug!("Fetching commit objects for {} at {}", self.url, oid_str);
 
         let callbacks = if let Some(provider) = &self.credential_provider {
             provider.build_callbacks(&self.url)
@@ -181,6 +200,7 @@ impl BareRepository {
             .fetch(&[&oid_str], Some(&mut fetch_options), None)
             .map_err(|e| GitError::Command(format!("git fetch {} failed: {}", oid_str, e)))?;
 
+        tracing::debug!("Fetched commit objects for {} at {}", self.url, oid_str);
         Ok(())
     }
 

--- a/nyl/src/git/worktree.rs
+++ b/nyl/src/git/worktree.rs
@@ -53,7 +53,14 @@ impl WorktreeManager {
             .arg("--detach")
             .arg(worktree_path)
             .arg(&oid_str)
-            .output()?;
+            .output()
+            .map_err(|e| {
+                GitError::WorktreeFailed(format!(
+                    "Failed to spawn 'git worktree add' for bare repo {}: {}. Ensure the 'git' CLI is installed and in PATH.",
+                    bare_repo_path.display(),
+                    e
+                ))
+            })?;
 
         if !output.status.success() {
             return Err(GitError::WorktreeFailed(format!(

--- a/nyl/src/helm/mod.rs
+++ b/nyl/src/helm/mod.rs
@@ -278,7 +278,10 @@ impl std::fmt::Debug for HelmChartResolver {
             .field("search_paths", &self.search_paths)
             .field("working_dir", &self.working_dir)
             .field("cache_dir", &self.cache_dir)
-            .field("credential_provider", &self.credential_provider)
+            .field(
+                "credential_provider",
+                &self.credential_provider.as_ref().map(|_| "<redacted>"),
+            )
             .finish()
     }
 }

--- a/nyl/src/helm/mod.rs
+++ b/nyl/src/helm/mod.rs
@@ -4,9 +4,11 @@
 /// - Chart resolution (local paths in Phase 2)
 /// - Template command building
 /// - Chart caching (stubbed for git/OCI in Phase 3)
+use crate::git::CredentialProvider;
 use crate::resources::ChartRef;
 use crate::{NylError, Result};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 mod oci;
 mod template;
@@ -61,6 +63,8 @@ pub struct HelmChartResolver {
 
     /// Optional cache directory for Git operations (defaults to env var/system default)
     cache_dir: Option<PathBuf>,
+
+    credential_provider: Option<Arc<CredentialProvider>>,
 }
 
 impl HelmChartResolver {
@@ -70,7 +74,7 @@ impl HelmChartResolver {
     /// * `search_paths` - Directories to search for charts
     /// * `working_dir` - Working directory for relative paths
     pub fn new(search_paths: Vec<PathBuf>, working_dir: PathBuf) -> Self {
-        Self::with_cache_dir(search_paths, working_dir, None)
+        Self::with_cache_dir_and_provider(search_paths, working_dir, None, None)
     }
 
     /// Create a new chart resolver with explicit cache directory
@@ -80,10 +84,20 @@ impl HelmChartResolver {
     /// * `working_dir` - Working directory for relative paths
     /// * `cache_dir` - Optional cache directory for Git operations (defaults to env var/system default)
     pub fn with_cache_dir(search_paths: Vec<PathBuf>, working_dir: PathBuf, cache_dir: Option<PathBuf>) -> Self {
+        Self::with_cache_dir_and_provider(search_paths, working_dir, cache_dir, None)
+    }
+
+    pub fn with_cache_dir_and_provider(
+        search_paths: Vec<PathBuf>,
+        working_dir: PathBuf,
+        cache_dir: Option<PathBuf>,
+        credential_provider: Option<Arc<CredentialProvider>>,
+    ) -> Self {
         Self {
             search_paths,
             working_dir,
             cache_dir,
+            credential_provider,
         }
     }
 
@@ -227,9 +241,9 @@ impl HelmChartResolver {
     /// Resolve a Git chart reference
     fn resolve_git(&self, repository_url: &str, chart_ref: &ChartRef) -> Result<ResolvedChart> {
         let mut git_manager = if let Some(ref cache_dir) = self.cache_dir {
-            crate::git::GitManager::with_cache_dir(cache_dir)
+            crate::git::GitManager::with_cache_dir_and_provider(cache_dir, self.credential_provider.clone())
         } else {
-            crate::git::GitManager::new()?
+            crate::git::GitManager::with_credential_provider(self.credential_provider.clone())?
         };
 
         // Use 'name' field as subpath for Git repos
@@ -264,6 +278,7 @@ impl std::fmt::Debug for HelmChartResolver {
             .field("search_paths", &self.search_paths)
             .field("working_dir", &self.working_dir)
             .field("cache_dir", &self.cache_dir)
+            .field("credential_provider", &self.credential_provider)
             .finish()
     }
 }


### PR DESCRIPTION

## Summary

- Auto-detect ArgoCD in-cluster context and wire discovered credentials through Git and Helm rendering paths.
- Remove the unsupported --in-cluster flag from CMP config and migration docs.

## Test plan

- [x] mise run fmt
- [x] mise run pre-commit


💘 Generated with Crush