### PR TITLE
feat(argocd): release-level customization policy for generated Applications

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,7 +169,10 @@ jobs:
             FULL_SHA="${{ github.event.pull_request.head.sha }}"
             SHORT_SHA="${FULL_SHA:0:7}"
             PR_NUMBER="${{ github.event.number }}"
-            CANONICAL_VERSION="0.0.0-pr.${PR_NUMBER}.sha.${SHORT_SHA}"
+            # Helm chart versions must be valid SemVer. Prefix the SHA segment
+            # with a letter so it is parsed as alphanumeric, not numeric with
+            # potential leading zeros.
+            CANONICAL_VERSION="0.0.0-pr.${PR_NUMBER}.sha.g${SHORT_SHA}"
             CAN_PUSH=$([ "${{ github.event.pull_request.head.repo.fork }}" = "true" ] && echo "false" || echo "true")
           elif [ "$EVENT_NAME" = "push" ] && [[ "$REF" == refs/tags/v* ]]; then
             TAG_VERSION="${REF_NAME#v}"
@@ -184,7 +187,7 @@ jobs:
             CANONICAL_VERSION="$TAG_VERSION"
             CAN_PUSH="true"
           else
-            CANONICAL_VERSION="0.0.0-dev.sha.${SHORT_SHA}"
+            CANONICAL_VERSION="0.0.0-dev.sha.g${SHORT_SHA}"
             CAN_PUSH="true"
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ mise run docs-rustdoc     # Generate API docs
 - Tests MUST NOT modify global state (env::set_var, static mut)
 - Use dependency injection for external dependencies (cache dirs, config paths)
 - Each test should use isolated temporary directories via `tempfile::TempDir`
+- Tests MUST NOT hardcode fixed temp paths like `/tmp/...`; always create per-test paths from `TempDir`
 
 **Example - DON'T:**
 ```rust

--- a/nyl/book/src/argocd/application-generator.md
+++ b/nyl/book/src/argocd/application-generator.md
@@ -152,7 +152,7 @@ Controls project-level `NylRelease.spec.argocd.applicationOverride` customizatio
 - If `allowedPaths` is omitted or null, defaults are used:
   - `metadata.annotations."pref.argocd.argoproj.io/*"`
   - `spec.info.**`
-  - `syncPolicy.**`
+  - `spec.syncPolicy.**`
 - If `allowedPaths` is an empty list, no fields are allowed.
 
 Ignored fields (unsupported/disallowed) are not applied and are reported in generated `Application.spec.info`.

--- a/nyl/book/src/argocd/application-generator.md
+++ b/nyl/book/src/argocd/application-generator.md
@@ -144,7 +144,8 @@ annotations:
 
 Controls project-level `NylRelease.spec.argocd.applicationOverride` customization of generated Applications.
 
-- If `releaseCustomization` is omitted, release overrides are ignored.
+- `NylRelease` overrides are always evaluated against effective `allowedPaths`/`deniedPaths`.
+- If `releaseCustomization` is omitted, defaults are used.
 - `allowedPaths` and `deniedPaths` use dotted field globs:
   - `*` matches one segment (does not cross dots)
   - `**` matches multiple segments (crosses dots)

--- a/nyl/book/src/argocd/application-generator.md
+++ b/nyl/book/src/argocd/application-generator.md
@@ -32,6 +32,9 @@ spec:
   applicationNameTemplate: string  # Naming template (default: "{{ .release.name }}")
   labels: {string: string}         # Labels for generated Applications
   annotations: {string: string}    # Annotations for generated Applications
+  releaseCustomization:            # Optional NylRelease override policy
+    allowedPaths: [string]
+    deniedPaths: [string]
 ```
 
 ## Field Reference
@@ -136,6 +139,23 @@ annotations:
   docs-url: https://wiki.example.com/apps
   team-slack: "#platform-team"
 ```
+
+### spec.releaseCustomization
+
+Controls project-level `NylRelease.spec.argocd.applicationOverride` customization of generated Applications.
+
+- If `releaseCustomization` is omitted, release overrides are ignored.
+- `allowedPaths` and `deniedPaths` use dotted field globs:
+  - `*` matches one segment (does not cross dots)
+  - `**` matches multiple segments (crosses dots)
+- If both allow and deny match, deny takes precedence.
+- If `allowedPaths` is omitted or null, defaults are used:
+  - `metadata.annotations."pref.argocd.argoproj.io/*"`
+  - `spec.info.**`
+  - `syncPolicy.**`
+- If `allowedPaths` is an empty list, no fields are allowed.
+
+Ignored fields (unsupported/disallowed) are not applied and are reported in generated `Application.spec.info`.
 
 ## File Filtering
 

--- a/nyl/book/src/reference/resources/application-generator.md
+++ b/nyl/book/src/reference/resources/application-generator.md
@@ -42,7 +42,7 @@ Key behavior:
 - A directory selector is scanned non-recursively by default.
 - Use glob selectors in `path`/`paths` when you want recursive discovery.
 - `include`/`exclude` patterns are matched against file paths relative to the repository root.
-- If `releaseCustomization` is present, `NylRelease.spec.argocd.applicationOverride` can customize allowed fields.
+- `NylRelease.spec.argocd.applicationOverride` is always evaluated against `allowedPaths`/`deniedPaths`.
 - `allowedPaths`/`deniedPaths` use dotted globs where `*` matches one segment and `**` matches multiple segments.
 - If both allow and deny match, deny wins. Ignored fields are reported in generated `Application.spec.info`.
 

--- a/nyl/book/src/reference/resources/application-generator.md
+++ b/nyl/book/src/reference/resources/application-generator.md
@@ -26,6 +26,13 @@ spec:
     automated:
       prune: true
       selfHeal: true
+  releaseCustomization:
+    allowedPaths:
+      - metadata.annotations."pref.argocd.argoproj.io/*"
+      - spec.info.**
+      - syncPolicy.**
+    deniedPaths:
+      - spec.syncPolicy.automated.prune
 ```
 
 The ApplicationGenerator resource enables automatic generation of ArgoCD Applications from NylRelease files in a directory.
@@ -35,5 +42,8 @@ Key behavior:
 - A directory selector is scanned non-recursively by default.
 - Use glob selectors in `path`/`paths` when you want recursive discovery.
 - `include`/`exclude` patterns are matched against file paths relative to the repository root.
+- If `releaseCustomization` is present, `NylRelease.spec.argocd.applicationOverride` can customize allowed fields.
+- `allowedPaths`/`deniedPaths` use dotted globs where `*` matches one segment and `**` matches multiple segments.
+- If both allow and deny match, deny wins. Ignored fields are reported in generated `Application.spec.info`.
 
 See the [full guide](../../argocd/application-generator.md) for complete field reference, examples, and usage patterns.

--- a/nyl/book/src/reference/resources/application-generator.md
+++ b/nyl/book/src/reference/resources/application-generator.md
@@ -30,7 +30,7 @@ spec:
     allowedPaths:
       - metadata.annotations."pref.argocd.argoproj.io/*"
       - spec.info.**
-      - syncPolicy.**
+      - spec.syncPolicy.**
     deniedPaths:
       - spec.syncPolicy.automated.prune
 ```

--- a/nyl/book/src/reference/resources/nyl-release.md
+++ b/nyl/book/src/reference/resources/nyl-release.md
@@ -11,6 +11,8 @@ metadata:
   name: string        # Release name
   namespace: string   # Target namespace
 spec: {}              # Reserved for future use
+  argocd:             # Optional ArgoCD customization
+    applicationOverride: {}   # Partial Application override (object)
 ```
 
 ## Field Reference
@@ -27,11 +29,14 @@ spec: {}              # Reserved for future use
 - **Description**: The target namespace for this release
 - **Usage**: Resources are deployed to this namespace
 
-### spec
+### spec.argocd.applicationOverride
 
 - **Type**: `object` (optional)
-- **Description**: Reserved for future metadata like labels, annotations
-- **Current**: Empty object (`{}`)
+- **Description**: Partial ArgoCD `Application` override for use with `ApplicationGenerator` release customization policy
+- **Behavior**:
+  - Override fields are applied only if allowed by `ApplicationGenerator.spec.releaseCustomization`
+  - Unsupported or disallowed fields are ignored
+  - Ignored fields are reported as a warning in generated `Application.spec.info`
 
 ## Behavior
 

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -1404,20 +1404,9 @@ fn insert_override_leaf(
 }
 
 fn path_matches_any(path: &str, patterns: &[impl AsRef<str>]) -> Result<bool> {
-    // Backward-compatibility alias:
-    // Historically, some patterns were written without the "spec." prefix
-    // (e.g. "syncPolicy.**"). We evaluate both forms so existing configs
-    // continue to match while docs/defaults now use full paths.
-    let mut candidates = vec![path.to_string()];
-    if let Some(stripped) = path.strip_prefix("spec.") {
-        candidates.push(stripped.to_string());
-    }
-
-    for candidate in &candidates {
-        for pattern in patterns {
-            if path_matches_glob(candidate, pattern.as_ref())? {
-                return Ok(true);
-            }
+    for pattern in patterns {
+        if path_matches_glob(path, pattern.as_ref())? {
+            return Ok(true);
         }
     }
     Ok(false)

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -1,5 +1,6 @@
 use clap::Args;
 use glob::{glob, Pattern};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -12,8 +13,8 @@ use crate::{
     profiles::{deep_merge_value, Profile, ProfileConfig},
     resources::{
         component_kind_to_chart_ref, extract_all_kyverno_policies, extract_application_generators, extract_nyl_release,
-        is_nyl_component, is_remote_helm_chart_shortcut, parse_component_kind, ChartRef, HelmChart, KyvernoScope,
-        NylComponent, NylRelease,
+        is_nyl_component, is_remote_helm_chart_shortcut, is_supported_application_field_path, join_field_path_segments,
+        parse_component_kind, path_matches_glob, ChartRef, HelmChart, KyvernoScope, NylComponent, NylRelease,
     },
     secrets::SecretsConfig,
     template::{TemplateContext, TemplateEngine},
@@ -1145,6 +1146,52 @@ fn matches_glob_patterns(relative_path: &Path, patterns: &[String]) -> Result<bo
     Ok(false)
 }
 
+const NYL_CUSTOMIZATION_WARNING_NAME: &str = "nyl-release-customization-warning";
+const IMMUTABLE_APPLICATION_PATH_PATTERNS: &[&str] = &[
+    "apiVersion",
+    "kind",
+    "metadata.name",
+    "metadata.namespace",
+    "spec.project",
+    "spec.source.repoURL",
+    "spec.source.path",
+    "spec.source.targetRevision",
+    "spec.source.plugin.name",
+    "spec.source.plugin.env.**",
+    "spec.destination.server",
+    "spec.destination.namespace",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum IgnoredOverrideReason {
+    CustomizationDisabled,
+    Disallowed,
+    Unsupported,
+}
+
+impl IgnoredOverrideReason {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::CustomizationDisabled => "customization-disabled",
+            Self::Disallowed => "disallowed",
+            Self::Unsupported => "unsupported",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct IgnoredOverride {
+    path: String,
+    reason: IgnoredOverrideReason,
+}
+
+#[derive(Debug, Clone)]
+struct OverrideLeaf {
+    segments: Vec<String>,
+    path: String,
+    value: serde_json::Value,
+}
+
 /// Create ArgoCD Application from generator config
 fn create_argocd_application_from_generator(
     release: &NylRelease,
@@ -1218,7 +1265,225 @@ fn create_argocd_application_from_generator(
         app["spec"]["syncPolicy"] = serde_json::to_value(sync_policy)?;
     }
 
+    apply_release_customization_overrides(&mut app, release, generator)?;
+
     Ok(app)
+}
+
+fn apply_release_customization_overrides(
+    app: &mut serde_json::Value,
+    release: &NylRelease,
+    generator: &crate::resources::ApplicationGenerator,
+) -> Result<()> {
+    let Some(application_override) = release
+        .spec
+        .argocd
+        .as_ref()
+        .and_then(|argocd| argocd.application_override.clone())
+    else {
+        return Ok(());
+    };
+
+    let mut override_leaves = Vec::new();
+    let mut prefix = Vec::new();
+    flatten_override_leaves(
+        &serde_json::Value::Object(application_override),
+        &mut prefix,
+        &mut override_leaves,
+    );
+
+    if override_leaves.is_empty() {
+        return Ok(());
+    }
+
+    let mut applied = Vec::new();
+    let mut ignored = Vec::new();
+
+    if let Some(customization) = &generator.spec.release_customization {
+        let allowed_paths = customization.effective_allowed_paths();
+        let denied_paths = &customization.denied_paths;
+        for leaf in override_leaves {
+            if !is_supported_application_field_path(&leaf.path) {
+                ignored.push(IgnoredOverride {
+                    path: leaf.path,
+                    reason: IgnoredOverrideReason::Unsupported,
+                });
+                continue;
+            }
+
+            if path_matches_any(&leaf.path, IMMUTABLE_APPLICATION_PATH_PATTERNS)? {
+                ignored.push(IgnoredOverride {
+                    path: leaf.path,
+                    reason: IgnoredOverrideReason::Disallowed,
+                });
+                continue;
+            }
+
+            let denied = path_matches_any(&leaf.path, denied_paths)?;
+            let allowed = path_matches_any(&leaf.path, &allowed_paths)?;
+            if denied || !allowed {
+                ignored.push(IgnoredOverride {
+                    path: leaf.path,
+                    reason: IgnoredOverrideReason::Disallowed,
+                });
+            } else {
+                applied.push(leaf);
+            }
+        }
+    } else {
+        for leaf in override_leaves {
+            ignored.push(IgnoredOverride {
+                path: leaf.path,
+                reason: IgnoredOverrideReason::CustomizationDisabled,
+            });
+        }
+    }
+
+    if !applied.is_empty() {
+        let override_value = build_override_value(&applied);
+        *app = deep_merge_value(Some(app.clone()), override_value);
+    }
+
+    if !ignored.is_empty() {
+        append_customization_warning(app, &ignored)?;
+    }
+
+    Ok(())
+}
+
+fn flatten_override_leaves(value: &serde_json::Value, prefix: &mut Vec<String>, leaves: &mut Vec<OverrideLeaf>) {
+    if let serde_json::Value::Object(map) = value {
+        if map.is_empty() {
+            return;
+        }
+        for (key, child) in map {
+            prefix.push(key.clone());
+            flatten_override_leaves(child, prefix, leaves);
+            prefix.pop();
+        }
+        return;
+    }
+
+    leaves.push(OverrideLeaf {
+        segments: prefix.clone(),
+        path: join_field_path_segments(prefix),
+        value: value.clone(),
+    });
+}
+
+fn build_override_value(leaves: &[OverrideLeaf]) -> serde_json::Value {
+    let mut root = serde_json::Map::new();
+    for leaf in leaves {
+        insert_override_leaf(&mut root, &leaf.segments, leaf.value.clone());
+    }
+    serde_json::Value::Object(root)
+}
+
+fn insert_override_leaf(
+    root: &mut serde_json::Map<String, serde_json::Value>,
+    segments: &[String],
+    value: serde_json::Value,
+) {
+    if segments.is_empty() {
+        return;
+    }
+    if segments.len() == 1 {
+        root.insert(segments[0].clone(), value);
+        return;
+    }
+
+    let entry = root
+        .entry(segments[0].clone())
+        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+    if !entry.is_object() {
+        *entry = serde_json::Value::Object(serde_json::Map::new());
+    }
+    if let Some(map) = entry.as_object_mut() {
+        insert_override_leaf(map, &segments[1..], value);
+    }
+}
+
+fn path_matches_any(path: &str, patterns: &[impl AsRef<str>]) -> Result<bool> {
+    let mut candidates = vec![path.to_string()];
+    if let Some(stripped) = path.strip_prefix("spec.") {
+        candidates.push(stripped.to_string());
+    }
+
+    for candidate in &candidates {
+        for pattern in patterns {
+            if path_matches_glob(candidate, pattern.as_ref())? {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
+fn append_customization_warning(app: &mut serde_json::Value, ignored: &[IgnoredOverride]) -> Result<()> {
+    let mut grouped: BTreeMap<&'static str, Vec<String>> = BTreeMap::new();
+    for item in ignored {
+        grouped.entry(item.reason.as_str()).or_default().push(item.path.clone());
+    }
+    for values in grouped.values_mut() {
+        values.sort();
+        values.dedup();
+    }
+
+    let summary = grouped
+        .iter()
+        .map(|(reason, paths)| format!("{}={} ({})", reason, paths.len(), summarize_paths(paths)))
+        .collect::<Vec<_>>()
+        .join("; ");
+    let warning_value = format!("Ignored NylRelease applicationOverride fields: {}", summary);
+
+    let spec = app
+        .get_mut("spec")
+        .and_then(|v| v.as_object_mut())
+        .ok_or_else(|| NylError::Config("Generated Application is missing spec".to_string()))?;
+    let info_value = spec
+        .entry("info".to_string())
+        .or_insert_with(|| serde_json::Value::Array(Vec::new()));
+    if !info_value.is_array() {
+        let previous = std::mem::take(info_value);
+        *info_value = serde_json::Value::Array(vec![previous]);
+    }
+
+    let info_items = info_value
+        .as_array_mut()
+        .ok_or_else(|| NylError::Config("Application spec.info is not an array".to_string()))?;
+
+    let mut existing_index = None;
+    for (idx, item) in info_items.iter().enumerate() {
+        if item
+            .get("name")
+            .and_then(|v| v.as_str())
+            .is_some_and(|name| name == NYL_CUSTOMIZATION_WARNING_NAME)
+        {
+            existing_index = Some(idx);
+            break;
+        }
+    }
+
+    let warning_item = serde_json::json!({
+        "name": NYL_CUSTOMIZATION_WARNING_NAME,
+        "value": warning_value,
+    });
+    if let Some(idx) = existing_index {
+        info_items[idx] = warning_item;
+    } else {
+        info_items.push(warning_item);
+    }
+
+    Ok(())
+}
+
+fn summarize_paths(paths: &[String]) -> String {
+    const LIMIT: usize = 5;
+    if paths.len() <= LIMIT {
+        return paths.join(", ");
+    }
+    let head = paths.iter().take(LIMIT).cloned().collect::<Vec<_>>();
+    format!("{}, +{} more", head.join(", "), paths.len() - LIMIT)
 }
 
 /// Normalize a relative path to POSIX-style separators.
@@ -1421,6 +1686,7 @@ metadata:
                 application_name_template: "{{ .release.name }}".to_string(),
                 labels: HashMap::new(),
                 annotations: HashMap::new(),
+                release_customization: None,
             },
         };
 
@@ -1438,6 +1704,158 @@ metadata:
             .and_then(|v| v["value"].as_str())
             .unwrap();
         assert_eq!(template_input, "nginx.yaml");
+    }
+
+    #[test]
+    fn test_release_customization_appends_warning_to_existing_info_entries() {
+        use crate::resources::{
+            ApplicationDestination, ApplicationGenerator, ApplicationGeneratorMetadata, ApplicationGeneratorSpec,
+            ApplicationSource, NylReleaseArgoCdSpec, NylReleaseMetadata, NylReleaseSpec, ReleaseCustomizationPolicy,
+        };
+        use std::collections::HashMap;
+        use std::path::Path;
+
+        let override_map = serde_json::from_value(serde_json::json!({
+            "spec": {
+                "info": [
+                    {"name": "team-note", "value": "kept"}
+                ],
+                "syncPolicy": {
+                    "automated": {
+                        "prune": true
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        let release = NylRelease {
+            api_version: API_VERSION.to_string(),
+            kind: "NylRelease".to_string(),
+            metadata: NylReleaseMetadata {
+                name: "nginx".to_string(),
+                namespace: "web".to_string(),
+            },
+            spec: NylReleaseSpec {
+                argocd: Some(NylReleaseArgoCdSpec {
+                    application_override: Some(override_map),
+                }),
+            },
+        };
+
+        let generator = ApplicationGenerator {
+            api_version: API_VERSION_ARGOCD.to_string(),
+            kind: "ApplicationGenerator".to_string(),
+            metadata: ApplicationGeneratorMetadata {
+                name: "apps".to_string(),
+                namespace: Some("argocd".to_string()),
+            },
+            spec: ApplicationGeneratorSpec {
+                destination: ApplicationDestination {
+                    server: "https://kubernetes.default.svc".to_string(),
+                    namespace: "argocd".to_string(),
+                },
+                source: ApplicationSource {
+                    repo_url: "https://github.com/example/repo.git".to_string(),
+                    target_revision: "HEAD".to_string(),
+                    path: Some("clusters/default".to_string()),
+                    paths: None,
+                    include: vec!["*.yaml".to_string()],
+                    exclude: vec![".*".to_string()],
+                },
+                project: "default".to_string(),
+                sync_policy: None,
+                application_name_template: "{{ .release.name }}".to_string(),
+                labels: HashMap::new(),
+                annotations: HashMap::new(),
+                release_customization: Some(ReleaseCustomizationPolicy {
+                    allowed_paths: Some(vec!["spec.info.**".to_string(), "spec.syncPolicy.**".to_string()]),
+                    denied_paths: vec!["spec.syncPolicy.automated.prune".to_string()],
+                }),
+            },
+        };
+
+        let file_path = Path::new("/tmp/worktree/clusters/default/addons/nginx.yaml");
+        let source_root = Path::new("/tmp/worktree");
+        let app = create_argocd_application_from_generator(&release, file_path, source_root, &generator).unwrap();
+
+        assert!(app["spec"]["syncPolicy"]["automated"]["prune"].is_null());
+        let info = app["spec"]["info"].as_array().unwrap();
+        assert!(info.iter().any(|entry| entry["name"] == "team-note"));
+        assert!(info.iter().any(|entry| entry["name"] == NYL_CUSTOMIZATION_WARNING_NAME));
+    }
+
+    #[test]
+    fn test_release_customization_uses_default_allowed_paths() {
+        use crate::resources::{
+            ApplicationDestination, ApplicationGenerator, ApplicationGeneratorMetadata, ApplicationGeneratorSpec,
+            ApplicationSource, NylReleaseArgoCdSpec, NylReleaseMetadata, NylReleaseSpec, ReleaseCustomizationPolicy,
+        };
+        use std::collections::HashMap;
+        use std::path::Path;
+
+        let override_map = serde_json::from_value(serde_json::json!({
+            "spec": {
+                "syncPolicy": {
+                    "automated": {
+                        "selfHeal": true
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        let release = NylRelease {
+            api_version: API_VERSION.to_string(),
+            kind: "NylRelease".to_string(),
+            metadata: NylReleaseMetadata {
+                name: "nginx".to_string(),
+                namespace: "web".to_string(),
+            },
+            spec: NylReleaseSpec {
+                argocd: Some(NylReleaseArgoCdSpec {
+                    application_override: Some(override_map),
+                }),
+            },
+        };
+
+        let generator = ApplicationGenerator {
+            api_version: API_VERSION_ARGOCD.to_string(),
+            kind: "ApplicationGenerator".to_string(),
+            metadata: ApplicationGeneratorMetadata {
+                name: "apps".to_string(),
+                namespace: Some("argocd".to_string()),
+            },
+            spec: ApplicationGeneratorSpec {
+                destination: ApplicationDestination {
+                    server: "https://kubernetes.default.svc".to_string(),
+                    namespace: "argocd".to_string(),
+                },
+                source: ApplicationSource {
+                    repo_url: "https://github.com/example/repo.git".to_string(),
+                    target_revision: "HEAD".to_string(),
+                    path: Some("clusters/default".to_string()),
+                    paths: None,
+                    include: vec!["*.yaml".to_string()],
+                    exclude: vec![".*".to_string()],
+                },
+                project: "default".to_string(),
+                sync_policy: None,
+                application_name_template: "{{ .release.name }}".to_string(),
+                labels: HashMap::new(),
+                annotations: HashMap::new(),
+                release_customization: Some(ReleaseCustomizationPolicy {
+                    allowed_paths: None,
+                    denied_paths: Vec::new(),
+                }),
+            },
+        };
+
+        let file_path = Path::new("/tmp/worktree/clusters/default/addons/nginx.yaml");
+        let source_root = Path::new("/tmp/worktree");
+        let app = create_argocd_application_from_generator(&release, file_path, source_root, &generator).unwrap();
+
+        assert_eq!(app["spec"]["syncPolicy"]["automated"]["selfHeal"], true);
     }
 
     #[test]
@@ -1481,6 +1899,7 @@ metadata:
                 application_name_template: "{{ .release.name }}".to_string(),
                 labels: HashMap::new(),
                 annotations: HashMap::new(),
+                release_customization: None,
             },
         };
 
@@ -1526,6 +1945,7 @@ metadata:
                 application_name_template: "{{ .release.name }}".to_string(),
                 labels: HashMap::new(),
                 annotations: HashMap::new(),
+                release_customization: None,
             },
         };
 
@@ -1573,6 +1993,7 @@ metadata:
                 application_name_template: "{{ .release.name }}".to_string(),
                 labels: HashMap::new(),
                 annotations: HashMap::new(),
+                release_customization: None,
             },
         };
 
@@ -1648,6 +2069,7 @@ metadata:
                 application_name_template: "{{ .release.name }}".to_string(),
                 labels: HashMap::new(),
                 annotations: HashMap::new(),
+                release_customization: None,
             },
         };
 

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -1164,7 +1164,6 @@ const IMMUTABLE_APPLICATION_PATH_PATTERNS: &[&str] = &[
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum IgnoredOverrideReason {
-    CustomizationDisabled,
     Disallowed,
     Unsupported,
 }
@@ -1172,7 +1171,6 @@ enum IgnoredOverrideReason {
 impl IgnoredOverrideReason {
     fn as_str(&self) -> &'static str {
         match self {
-            Self::CustomizationDisabled => "customization-disabled",
             Self::Disallowed => "disallowed",
             Self::Unsupported => "unsupported",
         }
@@ -1299,43 +1297,44 @@ fn apply_release_customization_overrides(
     let mut applied = Vec::new();
     let mut ignored = Vec::new();
 
-    if let Some(customization) = &generator.spec.release_customization {
-        let allowed_paths = customization.effective_allowed_paths();
-        let denied_paths = &customization.denied_paths;
-        for leaf in override_leaves {
-            if !is_supported_application_field_path(&leaf.path) {
-                ignored.push(IgnoredOverride {
-                    path: leaf.path,
-                    reason: IgnoredOverrideReason::Unsupported,
-                });
-                continue;
-            }
+    let customization =
+        generator
+            .spec
+            .release_customization
+            .clone()
+            .unwrap_or(crate::resources::ReleaseCustomizationPolicy {
+                allowed_paths: None,
+                denied_paths: Vec::new(),
+            });
+    let allowed_paths = customization.effective_allowed_paths();
+    let denied_paths = &customization.denied_paths;
 
-            if path_matches_any(&leaf.path, IMMUTABLE_APPLICATION_PATH_PATTERNS)? {
-                ignored.push(IgnoredOverride {
-                    path: leaf.path,
-                    reason: IgnoredOverrideReason::Disallowed,
-                });
-                continue;
-            }
-
-            let denied = path_matches_any(&leaf.path, denied_paths)?;
-            let allowed = path_matches_any(&leaf.path, &allowed_paths)?;
-            if denied || !allowed {
-                ignored.push(IgnoredOverride {
-                    path: leaf.path,
-                    reason: IgnoredOverrideReason::Disallowed,
-                });
-            } else {
-                applied.push(leaf);
-            }
-        }
-    } else {
-        for leaf in override_leaves {
+    for leaf in override_leaves {
+        if !is_supported_application_field_path(&leaf.path) {
             ignored.push(IgnoredOverride {
                 path: leaf.path,
-                reason: IgnoredOverrideReason::CustomizationDisabled,
+                reason: IgnoredOverrideReason::Unsupported,
             });
+            continue;
+        }
+
+        if path_matches_any(&leaf.path, IMMUTABLE_APPLICATION_PATH_PATTERNS)? {
+            ignored.push(IgnoredOverride {
+                path: leaf.path,
+                reason: IgnoredOverrideReason::Disallowed,
+            });
+            continue;
+        }
+
+        let denied = path_matches_any(&leaf.path, denied_paths)?;
+        let allowed = path_matches_any(&leaf.path, &allowed_paths)?;
+        if denied || !allowed {
+            ignored.push(IgnoredOverride {
+                path: leaf.path,
+                reason: IgnoredOverrideReason::Disallowed,
+            });
+        } else {
+            applied.push(leaf);
         }
     }
 
@@ -1841,6 +1840,76 @@ metadata:
                     allowed_paths: None,
                     denied_paths: Vec::new(),
                 }),
+            },
+        };
+
+        let file_path = Path::new("/tmp/worktree/clusters/default/addons/nginx.yaml");
+        let source_root = Path::new("/tmp/worktree");
+        let app = create_argocd_application_from_generator(&release, file_path, source_root, &generator).unwrap();
+
+        assert_eq!(app["spec"]["syncPolicy"]["automated"]["selfHeal"], true);
+    }
+
+    #[test]
+    fn test_release_customization_defaults_apply_when_policy_omitted() {
+        use crate::resources::{
+            ApplicationDestination, ApplicationGenerator, ApplicationGeneratorMetadata, ApplicationGeneratorSpec,
+            ApplicationSource, NylReleaseArgoCdSpec, NylReleaseMetadata, NylReleaseSpec,
+        };
+        use std::collections::HashMap;
+        use std::path::Path;
+
+        let override_map = serde_json::from_value(serde_json::json!({
+            "spec": {
+                "syncPolicy": {
+                    "automated": {
+                        "selfHeal": true
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        let release = NylRelease {
+            api_version: API_VERSION.to_string(),
+            kind: "NylRelease".to_string(),
+            metadata: NylReleaseMetadata {
+                name: "nginx".to_string(),
+                namespace: "web".to_string(),
+            },
+            spec: NylReleaseSpec {
+                argocd: Some(NylReleaseArgoCdSpec {
+                    application_override: Some(override_map),
+                }),
+            },
+        };
+
+        let generator = ApplicationGenerator {
+            api_version: API_VERSION_ARGOCD.to_string(),
+            kind: "ApplicationGenerator".to_string(),
+            metadata: ApplicationGeneratorMetadata {
+                name: "apps".to_string(),
+                namespace: Some("argocd".to_string()),
+            },
+            spec: ApplicationGeneratorSpec {
+                destination: ApplicationDestination {
+                    server: "https://kubernetes.default.svc".to_string(),
+                    namespace: "argocd".to_string(),
+                },
+                source: ApplicationSource {
+                    repo_url: "https://github.com/example/repo.git".to_string(),
+                    target_revision: "HEAD".to_string(),
+                    path: Some("clusters/default".to_string()),
+                    paths: None,
+                    include: vec!["*.yaml".to_string()],
+                    exclude: vec![".*".to_string()],
+                },
+                project: "default".to_string(),
+                sync_policy: None,
+                application_name_template: "{{ .release.name }}".to_string(),
+                labels: HashMap::new(),
+                annotations: HashMap::new(),
+                release_customization: None,
             },
         };
 

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -1404,6 +1404,10 @@ fn insert_override_leaf(
 }
 
 fn path_matches_any(path: &str, patterns: &[impl AsRef<str>]) -> Result<bool> {
+    // Backward-compatibility alias:
+    // Historically, some patterns were written without the "spec." prefix
+    // (e.g. "syncPolicy.**"). We evaluate both forms so existing configs
+    // continue to match while docs/defaults now use full paths.
     let mut candidates = vec![path.to_string()];
     if let Some(stripped) = path.strip_prefix("spec.") {
         candidates.push(stripped.to_string());

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -1537,6 +1537,7 @@ fn add_parent_annotations(
 mod tests {
     use super::*;
     use std::sync::Mutex;
+    use tempfile::TempDir;
 
     static APPGEN_OVERRIDE_ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -1545,6 +1546,15 @@ mod tests {
             file: None,
             config: crate::config::ProjectFile::default(),
         }
+    }
+
+    fn create_test_worktree_paths() -> (TempDir, std::path::PathBuf, std::path::PathBuf) {
+        let temp = TempDir::new().unwrap();
+        let source_root = temp.path().join("worktree");
+        let file_path = source_root.join("clusters/default/addons/nginx.yaml");
+        std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+        std::fs::write(&file_path, "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: test\n").unwrap();
+        (temp, source_root, file_path)
     }
 
     #[test]
@@ -1641,7 +1651,6 @@ metadata:
             ApplicationSource, NylReleaseMetadata, NylReleaseSpec,
         };
         use std::collections::HashMap;
-        use std::path::Path;
 
         let release = NylRelease {
             api_version: API_VERSION.to_string(),
@@ -1682,9 +1691,8 @@ metadata:
             },
         };
 
-        let file_path = Path::new("/tmp/worktree/clusters/default/addons/nginx.yaml");
-        let source_root = Path::new("/tmp/worktree");
-        let app = create_argocd_application_from_generator(&release, file_path, source_root, &generator).unwrap();
+        let (_temp, source_root, file_path) = create_test_worktree_paths();
+        let app = create_argocd_application_from_generator(&release, &file_path, &source_root, &generator).unwrap();
 
         assert_eq!(app["spec"]["source"]["path"], "clusters/default/addons");
         assert_eq!(app["spec"]["source"]["plugin"]["name"], "nyl-v2");
@@ -1705,7 +1713,6 @@ metadata:
             ApplicationSource, NylReleaseArgoCdSpec, NylReleaseMetadata, NylReleaseSpec, ReleaseCustomizationPolicy,
         };
         use std::collections::HashMap;
-        use std::path::Path;
 
         let override_map = serde_json::from_value(serde_json::json!({
             "spec": {
@@ -1767,9 +1774,8 @@ metadata:
             },
         };
 
-        let file_path = Path::new("/tmp/worktree/clusters/default/addons/nginx.yaml");
-        let source_root = Path::new("/tmp/worktree");
-        let app = create_argocd_application_from_generator(&release, file_path, source_root, &generator).unwrap();
+        let (_temp, source_root, file_path) = create_test_worktree_paths();
+        let app = create_argocd_application_from_generator(&release, &file_path, &source_root, &generator).unwrap();
 
         assert!(app["spec"]["syncPolicy"]["automated"]["prune"].is_null());
         let info = app["spec"]["info"].as_array().unwrap();
@@ -1784,7 +1790,6 @@ metadata:
             ApplicationSource, NylReleaseArgoCdSpec, NylReleaseMetadata, NylReleaseSpec, ReleaseCustomizationPolicy,
         };
         use std::collections::HashMap;
-        use std::path::Path;
 
         let override_map = serde_json::from_value(serde_json::json!({
             "spec": {
@@ -1843,9 +1848,8 @@ metadata:
             },
         };
 
-        let file_path = Path::new("/tmp/worktree/clusters/default/addons/nginx.yaml");
-        let source_root = Path::new("/tmp/worktree");
-        let app = create_argocd_application_from_generator(&release, file_path, source_root, &generator).unwrap();
+        let (_temp, source_root, file_path) = create_test_worktree_paths();
+        let app = create_argocd_application_from_generator(&release, &file_path, &source_root, &generator).unwrap();
 
         assert_eq!(app["spec"]["syncPolicy"]["automated"]["selfHeal"], true);
     }
@@ -1857,7 +1861,6 @@ metadata:
             ApplicationSource, NylReleaseArgoCdSpec, NylReleaseMetadata, NylReleaseSpec,
         };
         use std::collections::HashMap;
-        use std::path::Path;
 
         let override_map = serde_json::from_value(serde_json::json!({
             "spec": {
@@ -1913,9 +1916,8 @@ metadata:
             },
         };
 
-        let file_path = Path::new("/tmp/worktree/clusters/default/addons/nginx.yaml");
-        let source_root = Path::new("/tmp/worktree");
-        let app = create_argocd_application_from_generator(&release, file_path, source_root, &generator).unwrap();
+        let (_temp, source_root, file_path) = create_test_worktree_paths();
+        let app = create_argocd_application_from_generator(&release, &file_path, &source_root, &generator).unwrap();
 
         assert_eq!(app["spec"]["syncPolicy"]["automated"]["selfHeal"], true);
     }

--- a/nyl/src/git/mod.rs
+++ b/nyl/src/git/mod.rs
@@ -540,7 +540,11 @@ mod tests {
     fn test_resolve_ref_errors_when_fetch_fails_and_no_cached_ref() {
         let cache_dir = TempDir::new().unwrap();
         let mut manager = GitManager::with_cache_dir(cache_dir.path());
-        let url = "/tmp/nyl-does-not-exist-cred-test".to_string();
+        let url = cache_dir
+            .path()
+            .join("nyl-does-not-exist-cred-test")
+            .to_string_lossy()
+            .to_string();
 
         let bare_repo_path = manager.cache.bare_repo_path(&url);
         let raw_repo = Repository::init_bare(&bare_repo_path).unwrap();

--- a/nyl/src/resources/application_generator.rs
+++ b/nyl/src/resources/application_generator.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::constants::API_VERSION_ARGOCD;
+use crate::resources::validate_path_glob_pattern;
 use crate::{NylError, Result};
 
 /// ApplicationGenerator resource for ArgoCD bootstrapping
@@ -54,6 +55,21 @@ pub struct ApplicationGeneratorSpec {
     /// Annotations to add to generated Applications
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub annotations: HashMap<String, String>,
+    /// Project-level release customization policy for generated Applications
+    #[serde(skip_serializing_if = "Option::is_none", rename = "releaseCustomization")]
+    pub release_customization: Option<ReleaseCustomizationPolicy>,
+}
+
+/// Policy for project-controlled Application customization via NylRelease.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct ReleaseCustomizationPolicy {
+    /// Allowed path patterns. If omitted, defaults are used. If empty, nothing is allowed.
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "allowedPaths")]
+    pub allowed_paths: Option<Vec<String>>,
+    /// Denied path patterns that take precedence over allowed paths.
+    #[serde(default, skip_serializing_if = "Vec::is_empty", rename = "deniedPaths")]
+    pub denied_paths: Vec<String>,
 }
 
 /// Destination configuration for ArgoCD Applications
@@ -184,7 +200,30 @@ impl ApplicationGenerator {
         if self.spec.destination.namespace.is_empty() {
             return Err(NylError::Config("spec.destination.namespace is required".to_string()));
         }
+        if let Some(customization) = &self.spec.release_customization {
+            let patterns = customization.effective_allowed_paths();
+            for pattern in &patterns {
+                validate_path_glob_pattern(pattern)?;
+            }
+            for pattern in &customization.denied_paths {
+                validate_path_glob_pattern(pattern)?;
+            }
+        }
         Ok(())
+    }
+}
+
+impl ReleaseCustomizationPolicy {
+    pub const DEFAULT_ALLOWED_PATHS: [&str; 3] = [
+        "metadata.annotations.\"pref.argocd.argoproj.io/*\"",
+        "spec.info.**",
+        "syncPolicy.**",
+    ];
+
+    pub fn effective_allowed_paths(&self) -> Vec<String> {
+        self.allowed_paths
+            .clone()
+            .unwrap_or_else(|| Self::DEFAULT_ALLOWED_PATHS.iter().map(|s| (*s).to_string()).collect())
     }
 }
 
@@ -396,6 +435,7 @@ mod tests {
                 application_name_template: "{{ .release.name }}".to_string(),
                 labels: HashMap::new(),
                 annotations: HashMap::new(),
+                release_customization: None,
             },
         };
 
@@ -464,6 +504,32 @@ mod tests {
         let result = gen.validate();
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("namespace"));
+    }
+
+    #[test]
+    fn test_release_customization_default_allowed_paths() {
+        let policy = ReleaseCustomizationPolicy {
+            allowed_paths: None,
+            denied_paths: Vec::new(),
+        };
+        assert_eq!(
+            policy.effective_allowed_paths(),
+            vec![
+                "metadata.annotations.\"pref.argocd.argoproj.io/*\"".to_string(),
+                "spec.info.**".to_string(),
+                "syncPolicy.**".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_validate_release_customization_patterns() {
+        let mut gen = create_test_generator();
+        gen.spec.release_customization = Some(ReleaseCustomizationPolicy {
+            allowed_paths: Some(vec!["spec.syncPolicy.**".to_string()]),
+            denied_paths: vec!["spec.syncPolicy.automated.*".to_string()],
+        });
+        assert!(gen.validate().is_ok());
     }
 
     #[test]
@@ -630,6 +696,7 @@ mod tests {
                 application_name_template: "{{ .release.name }}".to_string(),
                 labels: HashMap::new(),
                 annotations: HashMap::new(),
+                release_customization: None,
             },
         }
     }

--- a/nyl/src/resources/application_generator.rs
+++ b/nyl/src/resources/application_generator.rs
@@ -217,7 +217,7 @@ impl ReleaseCustomizationPolicy {
     pub const DEFAULT_ALLOWED_PATHS: [&str; 3] = [
         "metadata.annotations.\"pref.argocd.argoproj.io/*\"",
         "spec.info.**",
-        "syncPolicy.**",
+        "spec.syncPolicy.**",
     ];
 
     pub fn effective_allowed_paths(&self) -> Vec<String> {
@@ -517,7 +517,7 @@ mod tests {
             vec![
                 "metadata.annotations.\"pref.argocd.argoproj.io/*\"".to_string(),
                 "spec.info.**".to_string(),
-                "syncPolicy.**".to_string(),
+                "spec.syncPolicy.**".to_string(),
             ]
         );
     }

--- a/nyl/src/resources/argocd_application_field_catalog.rs
+++ b/nyl/src/resources/argocd_application_field_catalog.rs
@@ -1,0 +1,58 @@
+use crate::resources::path_glob::path_matches_glob;
+
+/// Known ArgoCD Application field-path patterns.
+///
+/// This inventory is periodically updated from the ArgoCD Application CRD.
+/// Paths use dotted notation with quoted segments where needed.
+const VALID_APPLICATION_PATH_PATTERNS: &[&str] = &[
+    "apiVersion",
+    "kind",
+    "metadata.name",
+    "metadata.namespace",
+    "metadata.labels.**",
+    "metadata.annotations.**",
+    "metadata.finalizers.**",
+    "spec.project",
+    "spec.source.repoURL",
+    "spec.source.path",
+    "spec.source.targetRevision",
+    "spec.source.chart",
+    "spec.source.helm.**",
+    "spec.source.kustomize.**",
+    "spec.source.directory.**",
+    "spec.source.jsonnet.**",
+    "spec.source.plugin.name",
+    "spec.source.plugin.env.**",
+    "spec.sources.**",
+    "spec.destination.server",
+    "spec.destination.name",
+    "spec.destination.namespace",
+    "spec.syncPolicy.**",
+    "spec.ignoreDifferences.**",
+    "spec.revisionHistoryLimit",
+    "spec.info.**",
+];
+
+pub fn is_supported_application_field_path(path: &str) -> bool {
+    VALID_APPLICATION_PATH_PATTERNS.iter().any(|pattern| {
+        path_matches_glob(path, pattern).unwrap_or_else(|_| panic!("invalid field catalog pattern: {}", pattern))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_supported_field_path() {
+        assert!(is_supported_application_field_path("spec.syncPolicy.automated.prune"));
+        assert!(is_supported_application_field_path(
+            "metadata.annotations.\"foo.bar/baz\""
+        ));
+    }
+
+    #[test]
+    fn test_unsupported_field_path() {
+        assert!(!is_supported_application_field_path("spec.notRealField.foo"));
+    }
+}

--- a/nyl/src/resources/argocd_application_field_catalog.rs
+++ b/nyl/src/resources/argocd_application_field_catalog.rs
@@ -34,14 +34,15 @@ const VALID_APPLICATION_PATH_PATTERNS: &[&str] = &[
 ];
 
 pub fn is_supported_application_field_path(path: &str) -> bool {
-    VALID_APPLICATION_PATH_PATTERNS.iter().any(|pattern| {
-        path_matches_glob(path, pattern).unwrap_or_else(|_| panic!("invalid field catalog pattern: {}", pattern))
-    })
+    VALID_APPLICATION_PATH_PATTERNS
+        .iter()
+        .any(|pattern| path_matches_glob(path, pattern).unwrap_or(false))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::resources::path_glob::validate_path_glob_pattern;
 
     #[test]
     fn test_supported_field_path() {
@@ -54,5 +55,14 @@ mod tests {
     #[test]
     fn test_unsupported_field_path() {
         assert!(!is_supported_application_field_path("spec.notRealField.foo"));
+    }
+
+    #[test]
+    fn test_field_catalog_patterns_are_valid() {
+        for pattern in VALID_APPLICATION_PATH_PATTERNS {
+            validate_path_glob_pattern(pattern).unwrap_or_else(|e| {
+                panic!("invalid field catalog pattern '{}': {}", pattern, e);
+            });
+        }
     }
 }

--- a/nyl/src/resources/mod.rs
+++ b/nyl/src/resources/mod.rs
@@ -2,15 +2,18 @@
 ///
 /// This module provides Kubernetes-style resource definitions for Nyl
 mod application_generator;
+mod argocd_application_field_catalog;
 mod component;
 mod helmchart;
 mod kyverno;
 mod nyl_release;
+mod path_glob;
 
 pub use application_generator::{
     extract_application_generators, ApplicationDestination, ApplicationGenerator, ApplicationGeneratorMetadata,
-    ApplicationGeneratorSpec, ApplicationSource, AutomatedSyncPolicy, SyncPolicy,
+    ApplicationGeneratorSpec, ApplicationSource, AutomatedSyncPolicy, ReleaseCustomizationPolicy, SyncPolicy,
 };
+pub use argocd_application_field_catalog::is_supported_application_field_path;
 pub use component::{
     component_kind_to_chart_ref, is_nyl_component, is_remote_helm_chart_shortcut, parse_component_kind,
     ComponentKindParsed, NylComponent,
@@ -20,4 +23,5 @@ pub use kyverno::{
     extract_all_kyverno_policies, extract_policies_by_scope, has_kyverno_scope_annotation, is_kyverno_policy,
     AnnotatedKyvernoPolicy, KyvernoScope,
 };
-pub use nyl_release::{extract_nyl_release, NylRelease, NylReleaseMetadata, NylReleaseSpec};
+pub use nyl_release::{extract_nyl_release, NylRelease, NylReleaseArgoCdSpec, NylReleaseMetadata, NylReleaseSpec};
+pub use path_glob::{join_segments as join_field_path_segments, path_matches_glob, validate_path_glob_pattern};

--- a/nyl/src/resources/nyl_release.rs
+++ b/nyl/src/resources/nyl_release.rs
@@ -3,7 +3,7 @@
 /// This is an optional resource that can be included in YAML files to specify
 /// release metadata. When present, it provides the release name and namespace.
 /// When absent, these values must be provided via CLI flags.
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::constants::API_VERSION;
 use crate::{NylError, Result};
@@ -34,7 +34,41 @@ pub struct NylReleaseMetadata {
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct NylReleaseSpec {
-    // Future: additional metadata like labels, annotations
+    /// ArgoCD-specific options.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub argocd: Option<NylReleaseArgoCdSpec>,
+}
+
+/// ArgoCD-specific options for NylRelease.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct NylReleaseArgoCdSpec {
+    /// Optional partial ArgoCD Application override.
+    ///
+    /// Must be an object if provided.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "applicationOverride",
+        deserialize_with = "deserialize_optional_object"
+    )]
+    pub application_override: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
+fn deserialize_optional_object<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<serde_json::Map<String, serde_json::Value>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    match value {
+        None => Ok(None),
+        Some(serde_json::Value::Object(map)) => Ok(Some(map)),
+        Some(_) => Err(serde::de::Error::custom(
+            "applicationOverride must be a YAML/JSON object",
+        )),
+    }
 }
 
 impl NylRelease {
@@ -154,6 +188,39 @@ mod tests {
     }
 
     #[test]
+    fn test_from_value_with_application_override() {
+        let value = json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "NylRelease",
+            "metadata": {
+                "name": "myapp",
+                "namespace": "production"
+            },
+            "spec": {
+                "argocd": {
+                    "applicationOverride": {
+                        "spec": {
+                            "syncPolicy": {
+                                "automated": {
+                                    "prune": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let release = NylRelease::from_value(&value).unwrap();
+        let application_override = release
+            .spec
+            .argocd
+            .and_then(|a| a.application_override)
+            .expect("applicationOverride should be parsed");
+        assert!(application_override.contains_key("spec"));
+    }
+
+    #[test]
     fn test_from_value_invalid_missing_metadata() {
         let value = json!({
             "apiVersion": "nyl.niklasrosenstein.github.com/v1",
@@ -254,5 +321,23 @@ unknownField: should-fail
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("unknown field"));
+    }
+
+    #[test]
+    fn test_nyl_release_rejects_non_object_application_override() {
+        let yaml = r"
+apiVersion: nyl.niklasrosenstein.github.com/v1
+kind: NylRelease
+metadata:
+  name: test
+  namespace: default
+spec:
+  argocd:
+    applicationOverride: hello
+";
+        let result: std::result::Result<NylRelease, _> = serde_norway::from_str(yaml);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("applicationOverride must be a YAML/JSON object"));
     }
 }

--- a/nyl/src/resources/path_glob.rs
+++ b/nyl/src/resources/path_glob.rs
@@ -73,11 +73,19 @@ fn parse_pattern(pattern: &str) -> Result<Vec<PatternSegment>> {
     }
 
     let mut parsed = Vec::with_capacity(segments.len());
+    let mut previous_was_double_star = false;
     for segment in segments {
         if segment == "**" {
+            if previous_was_double_star {
+                return Err(NylError::Config(
+                    "Invalid path pattern: consecutive '**' segments are not allowed".to_string(),
+                ));
+            }
             parsed.push(PatternSegment::DoubleStar);
+            previous_was_double_star = true;
             continue;
         }
+        previous_was_double_star = false;
         if segment.contains("**") {
             return Err(NylError::Config(format!(
                 "Invalid path pattern segment '{}': '**' must be a standalone segment",
@@ -207,5 +215,11 @@ mod tests {
             "pref.argocd.argoproj.io/foo".to_string(),
         ]);
         assert_eq!(joined, "metadata.annotations.\"pref.argocd.argoproj.io/foo\"");
+    }
+
+    #[test]
+    fn test_validate_path_glob_pattern_rejects_consecutive_double_star() {
+        let err = validate_path_glob_pattern("spec.**.**.syncPolicy").unwrap_err();
+        assert!(err.to_string().contains("consecutive '**' segments are not allowed"));
     }
 }

--- a/nyl/src/resources/path_glob.rs
+++ b/nyl/src/resources/path_glob.rs
@@ -1,0 +1,211 @@
+use glob::Pattern;
+
+use crate::{NylError, Result};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PatternSegment {
+    DoubleStar,
+    Segment(String),
+}
+
+/// Validate a dotted field-path glob pattern.
+pub fn validate_path_glob_pattern(pattern: &str) -> Result<()> {
+    let _ = parse_pattern(pattern)?;
+    Ok(())
+}
+
+/// Match a concrete dotted path against a dotted glob pattern.
+///
+/// Rules:
+/// - `*` matches any characters within a single segment.
+/// - `**` matches zero or more full segments.
+pub fn path_matches_glob(path: &str, pattern: &str) -> Result<bool> {
+    let path_segments = parse_concrete_path(path)?;
+    let pattern_segments = parse_pattern(pattern)?;
+    Ok(matches_segments(&path_segments, &pattern_segments, 0, 0))
+}
+
+/// Join path segments into normalized dotted notation.
+///
+/// Segments containing non-identifier chars are quoted.
+pub fn join_segments(segments: &[String]) -> String {
+    segments
+        .iter()
+        .map(|segment| {
+            if is_simple_identifier(segment) {
+                segment.clone()
+            } else {
+                let escaped = segment.replace('\\', "\\\\").replace('"', "\\\"");
+                format!("\"{}\"", escaped)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+fn is_simple_identifier(segment: &str) -> bool {
+    !segment.is_empty()
+        && segment
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
+fn parse_concrete_path(path: &str) -> Result<Vec<String>> {
+    let segments = split_segments(path)?;
+    if segments.is_empty() {
+        return Err(NylError::Config("Field path must not be empty".to_string()));
+    }
+
+    if segments.iter().any(|segment| segment == "**") {
+        return Err(NylError::Config(format!(
+            "Concrete field path must not contain '**': {}",
+            path
+        )));
+    }
+
+    Ok(segments)
+}
+
+fn parse_pattern(pattern: &str) -> Result<Vec<PatternSegment>> {
+    let segments = split_segments(pattern)?;
+    if segments.is_empty() {
+        return Err(NylError::Config("Path pattern must not be empty".to_string()));
+    }
+
+    let mut parsed = Vec::with_capacity(segments.len());
+    for segment in segments {
+        if segment == "**" {
+            parsed.push(PatternSegment::DoubleStar);
+            continue;
+        }
+        if segment.contains("**") {
+            return Err(NylError::Config(format!(
+                "Invalid path pattern segment '{}': '**' must be a standalone segment",
+                segment
+            )));
+        }
+        Pattern::new(&segment)
+            .map_err(|e| NylError::Config(format!("Invalid path pattern segment '{}': {}", segment, e)))?;
+        parsed.push(PatternSegment::Segment(segment));
+    }
+
+    Ok(parsed)
+}
+
+fn split_segments(input: &str) -> Result<Vec<String>> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    let mut escape = false;
+
+    for ch in input.chars() {
+        if escape {
+            current.push(ch);
+            escape = false;
+            continue;
+        }
+
+        match ch {
+            '\\' if in_quotes => {
+                escape = true;
+            }
+            '"' => {
+                in_quotes = !in_quotes;
+            }
+            '.' if !in_quotes => {
+                if current.is_empty() {
+                    return Err(NylError::Config(format!("Invalid path '{}': empty segment", input)));
+                }
+                segments.push(std::mem::take(&mut current));
+            }
+            _ => current.push(ch),
+        }
+    }
+
+    if in_quotes {
+        return Err(NylError::Config(format!("Invalid path '{}': unmatched quote", input)));
+    }
+    if escape {
+        return Err(NylError::Config(format!("Invalid path '{}': dangling escape", input)));
+    }
+    if current.is_empty() {
+        return Err(NylError::Config(format!(
+            "Invalid path '{}': empty trailing segment",
+            input
+        )));
+    }
+
+    segments.push(current);
+    Ok(segments)
+}
+
+fn matches_segments(path: &[String], pattern: &[PatternSegment], pi: usize, si: usize) -> bool {
+    if si == pattern.len() {
+        return pi == path.len();
+    }
+
+    match &pattern[si] {
+        PatternSegment::DoubleStar => {
+            if matches_segments(path, pattern, pi, si + 1) {
+                return true;
+            }
+            let mut idx = pi;
+            while idx < path.len() {
+                if matches_segments(path, pattern, idx + 1, si) {
+                    return true;
+                }
+                idx += 1;
+            }
+            false
+        }
+        PatternSegment::Segment(pattern_segment) => {
+            if pi >= path.len() {
+                return false;
+            }
+            let Ok(glob) = Pattern::new(pattern_segment) else {
+                return false;
+            };
+            if glob.matches(&path[pi]) {
+                matches_segments(path, pattern, pi + 1, si + 1)
+            } else {
+                false
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_path_matches_glob_single_segment_star() {
+        assert!(path_matches_glob("spec.syncPolicy.automated", "spec.*.automated").unwrap());
+        assert!(!path_matches_glob("spec.syncPolicy.automated.prune", "spec.*.automated").unwrap());
+    }
+
+    #[test]
+    fn test_path_matches_glob_double_star() {
+        assert!(path_matches_glob("spec.syncPolicy", "spec.syncPolicy.**").unwrap());
+        assert!(path_matches_glob("spec.syncPolicy.automated.prune", "spec.syncPolicy.**").unwrap());
+    }
+
+    #[test]
+    fn test_path_matches_glob_quoted_segment() {
+        assert!(path_matches_glob(
+            "metadata.annotations.\"pref.argocd.argoproj.io/foo\"",
+            "metadata.annotations.\"pref.argocd.argoproj.io/*\""
+        )
+        .unwrap());
+    }
+
+    #[test]
+    fn test_join_segments_quotes_special_segments() {
+        let joined = join_segments(&[
+            "metadata".to_string(),
+            "annotations".to_string(),
+            "pref.argocd.argoproj.io/foo".to_string(),
+        ]);
+        assert_eq!(joined, "metadata.annotations.\"pref.argocd.argoproj.io/foo\"");
+    }
+}

--- a/nyl/src/secrets/null.rs
+++ b/nyl/src/secrets/null.rs
@@ -54,7 +54,7 @@ impl SecretProvider for NullProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
+    use tempfile::TempDir;
 
     #[test]
     fn test_null_provider_new() {
@@ -65,7 +65,8 @@ mod tests {
     #[test]
     fn test_null_provider_init() {
         let mut provider = NullProvider::new();
-        let result = provider.init(&PathBuf::from("/tmp/test.yaml"));
+        let temp = TempDir::new().unwrap();
+        let result = provider.init(&temp.path().join("test.yaml"));
         assert!(result.is_ok());
     }
 


### PR DESCRIPTION
## Summary
- add `NylRelease.spec.argocd.applicationOverride` (object-only) for project-level Application customization
- add `ApplicationGenerator.spec.releaseCustomization` policy with `allowedPaths`/`deniedPaths`
- implement dotted glob matching semantics (`*` single-segment, `**` multi-segment) with quoted-segment support
- add static ArgoCD Application field catalog for supported override-path validation
- apply only supported+allowed (and not denied) override paths during Application generation
- ignore unsupported/disallowed fields and append a warning item to generated `Application.spec.info`
- ensure warning is appended even when override-provided `spec.info` entries are allowed and present
- keep deny precedence over allow and default allowlist when `allowedPaths` is omitted/null

## Default allowlist
When `releaseCustomization.allowedPaths` is omitted/null:
- `metadata.annotations."pref.argocd.argoproj.io/*"`
- `spec.info.**`
- `syncPolicy.**`

## Validation and behavior details
- if `releaseCustomization` is absent, overrides are ignored and warning is added
- if `allowedPaths` is empty (`[]`), no fields are allowed
- `deniedPaths` takes precedence over `allowedPaths`
- override warnings are deduplicated/updated via a stable `spec.info` entry name: `nyl-release-customization-warning`

## Docs
- update NylRelease and ApplicationGenerator reference docs
- update ArgoCD ApplicationGenerator guide with release customization policy and warning behavior

## Testing
- `mise run pre-commit`
- `cd nyl && cargo test -q`
- `cd nyl && cargo clippy -q --all-targets -- -D warnings`
