### PR TITLE
fix: normalize resource parse error messages

### DIFF
--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -583,7 +583,7 @@ fn generate_resource(
     if kind == Some("HelmChart") && api_version == Some(API_VERSION) {
         // Parse as HelmChart and render
         let chart: HelmChart = serde_json::from_value(resource.clone())
-            .map_err(|e| NylError::Config(format!("Failed to parse HelmChart: {}", e)))?;
+            .map_err(|e| crate::util::map_resource_parse_error("HelmChart", &e))?;
         let manifests = render_helm_chart(
             &chart,
             context,
@@ -619,7 +619,7 @@ fn generate_resource(
     {
         // Parse as Component and render via the existing Helm path
         let mut component: NylComponent = serde_json::from_value(resource.clone())
-            .map_err(|e| NylError::Config(format!("Failed to parse Component: {}", e)))?;
+            .map_err(|e| crate::util::map_resource_parse_error("Component", &e))?;
         if let Some(target) = config.get_alias_target_for_kind(&component.api_version, &component.kind) {
             component.kind = target.to_string();
         }

--- a/nyl/src/resources/application_generator.rs
+++ b/nyl/src/resources/application_generator.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 
 use crate::constants::API_VERSION_ARGOCD;
 use crate::resources::validate_path_glob_pattern;
+use crate::util::map_resource_parse_error;
 use crate::{NylError, Result};
 
 /// ApplicationGenerator resource for ArgoCD bootstrapping
@@ -160,8 +161,7 @@ impl ApplicationGenerator {
 
     /// Parse ApplicationGenerator from JSON value
     pub fn from_value(value: &serde_json::Value) -> Result<Self> {
-        serde_json::from_value(value.clone())
-            .map_err(|e| NylError::Config(format!("Invalid ApplicationGenerator resource: {}", e)))
+        serde_json::from_value(value.clone()).map_err(|e| map_resource_parse_error("ApplicationGenerator", &e))
     }
 
     /// Validate the ApplicationGenerator configuration
@@ -721,5 +721,33 @@ spec:
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("unknown field"));
+    }
+
+    #[test]
+    fn test_from_value_unknown_field_message_is_human_friendly() {
+        let value = json!({
+            "apiVersion": "argocd.nyl.niklasrosenstein.github.com/v1",
+            "kind": "ApplicationGenerator",
+            "metadata": {
+                "name": "test",
+                "namespace": "argocd"
+            },
+            "spec": {
+                "destination": {
+                    "server": "https://kubernetes.default.svc",
+                    "namespace": "argocd"
+                },
+                "source": {
+                    "repoURL": "https://github.com/example/repo",
+                    "path": "clusters/default"
+                },
+                "unexpectedField": true
+            }
+        });
+
+        let err = ApplicationGenerator::from_value(&value).unwrap_err().to_string();
+        assert!(err.contains("Unknown field 'unexpectedField' in ApplicationGenerator."));
+        assert!(!err.contains("there are no fields"));
+        assert!(err.contains("Check for typos"));
     }
 }

--- a/nyl/src/resources/nyl_release.rs
+++ b/nyl/src/resources/nyl_release.rs
@@ -6,6 +6,7 @@
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::constants::API_VERSION;
+use crate::util::map_resource_parse_error;
 use crate::{NylError, Result};
 
 /// NylRelease resource for specifying release metadata
@@ -80,8 +81,7 @@ impl NylRelease {
 
     /// Parse NylRelease from JSON value
     pub fn from_value(value: &serde_json::Value) -> Result<Self> {
-        serde_json::from_value(value.clone())
-            .map_err(|e| NylError::Config(format!("Invalid NylRelease resource: {}", e)))
+        serde_json::from_value(value.clone()).map_err(|e| map_resource_parse_error("NylRelease", &e))
     }
 }
 
@@ -339,5 +339,27 @@ spec:
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("applicationOverride must be a YAML/JSON object"));
+    }
+
+    #[test]
+    fn test_from_value_unknown_field_message_is_human_friendly() {
+        let value = json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "NylRelease",
+            "metadata": {
+                "name": "test",
+                "namespace": "default"
+            },
+            "spec": {
+                "argocd": {
+                    "unexpectedField": true
+                }
+            }
+        });
+
+        let err = NylRelease::from_value(&value).unwrap_err().to_string();
+        assert!(err.contains("Unknown field 'unexpectedField' in NylRelease."));
+        assert!(!err.contains("there are no fields"));
+        assert!(err.contains("Check for typos"));
     }
 }

--- a/nyl/src/util/mod.rs
+++ b/nyl/src/util/mod.rs
@@ -7,9 +7,11 @@
 use sha2::{Digest, Sha256};
 
 pub mod fs;
+pub mod resource_parse_error;
 pub mod source_context;
 
 pub use fs::{find_config_file, resolve_path, resolve_paths};
+pub use resource_parse_error::map_resource_parse_error;
 pub use source_context::SourceContext;
 
 /// Compute SHA256 hash of a string

--- a/nyl/src/util/resource_parse_error.rs
+++ b/nyl/src/util/resource_parse_error.rs
@@ -1,0 +1,81 @@
+use crate::NylError;
+
+const MANIFEST_RESOURCE_SOURCE: &str = "<manifest resource>";
+const UNKNOWN_FIELD_HINT: &str = "Check for typos and verify field names against the resource reference documentation.";
+
+/// Convert serde_json parse errors for typed resources into consistent diagnostics.
+pub fn map_resource_parse_error(resource_kind: &str, error: &serde_json::Error) -> NylError {
+    let raw_error = error.to_string();
+
+    if let Some(field_name) = extract_unknown_field_name(&raw_error) {
+        let message = format!("Unknown field '{}' in {}.", field_name, resource_kind);
+        return NylError::resource_validation(MANIFEST_RESOURCE_SOURCE, message, UNKNOWN_FIELD_HINT);
+    }
+
+    let cleaned_error = normalize_raw_error(&raw_error);
+    let message = format!("Failed to parse {}: {}", resource_kind, cleaned_error);
+    NylError::resource_validation(
+        MANIFEST_RESOURCE_SOURCE,
+        message,
+        "Check the resource structure and value types against the resource reference documentation.",
+    )
+}
+
+fn extract_unknown_field_name(error_msg: &str) -> Option<String> {
+    let marker = "unknown field `";
+    let start = error_msg.find(marker)?;
+    let after_marker = &error_msg[start + marker.len()..];
+    let end = after_marker.find('`')?;
+    Some(after_marker[..end].to_string())
+}
+
+fn normalize_raw_error(error_msg: &str) -> String {
+    error_msg.replace(", there are no fields", "")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+    use serde_json::json;
+
+    #[test]
+    fn test_unknown_field_message_is_normalized() {
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Empty {}
+
+        let serde_err = serde_json::from_value::<Empty>(json!({
+            "argocd": {}
+        }))
+        .unwrap_err();
+
+        let err = map_resource_parse_error("NylRelease", &serde_err);
+        let display = err.to_string();
+
+        assert!(display.contains("Unknown field 'argocd' in NylRelease."));
+        assert!(!display.contains("there are no fields"));
+        assert!(display.contains("Check for typos"));
+    }
+
+    #[test]
+    fn test_non_unknown_field_message_uses_fallback() {
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize)]
+        struct Typed {
+            replicas: u32,
+        }
+
+        let serde_err = serde_json::from_value::<Typed>(json!({
+            "replicas": "three"
+        }))
+        .unwrap_err();
+
+        let err = map_resource_parse_error("HelmChart", &serde_err);
+        let display = err.to_string();
+
+        assert!(display.contains("Failed to parse HelmChart:"));
+        assert!(display.contains("invalid type"));
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared `map_resource_parse_error()` helper for serde-based resource parsing errors
- normalize unknown-field diagnostics to human-readable messages and remove awkward tails like `there are no fields`
- route NylRelease, ApplicationGenerator, HelmChart, and Component parse failures through `ResourceValidation` hints

## Tests
- cargo test resource_parse_error --lib
- cargo test test_from_value_unknown_field_message_is_human_friendly --lib
- cargo test rejects_unknown_fields --lib
