### PR TITLE
fix: resolve namespace scope via CRD metadata when discovery misses kinds

### DIFF
--- a/nyl/src/cli/namespace_resolution.rs
+++ b/nyl/src/cli/namespace_resolution.rs
@@ -37,7 +37,19 @@ pub async fn resolve_manifest_namespaces(
         let is_namespaced = if let Some(cached) = scope_cache.get(&key.gvk) {
             *cached
         } else {
-            let discovered = client.is_namespaced(&key.gvk).await?;
+            let discovered = match client.is_namespaced(&key.gvk).await {
+                Ok(v) => v,
+                Err(err) if is_api_resource_not_found_error(&err) => {
+                    tracing::warn!(
+                        api_version = %format_api_version(&key.gvk),
+                        kind = %key.gvk.kind,
+                        "Skipping namespace resolution for resource with unknown API discovery"
+                    );
+                    scope_cache.insert(key.gvk.clone(), false);
+                    continue;
+                }
+                Err(err) => return Err(err),
+            };
             scope_cache.insert(key.gvk.clone(), discovered);
             discovered
         };
@@ -101,7 +113,20 @@ pub async fn adjust_duplicate_keys_for_namespace_resolution(
         let is_namespaced = if let Some(cached) = scope_cache.get(&key.gvk) {
             *cached
         } else {
-            let discovered = client.is_namespaced(&key.gvk).await?;
+            let discovered = match client.is_namespaced(&key.gvk).await {
+                Ok(v) => v,
+                Err(err) if is_api_resource_not_found_error(&err) => {
+                    tracing::warn!(
+                        api_version = %format_api_version(&key.gvk),
+                        kind = %key.gvk.kind,
+                        "Skipping duplicate-key namespace adjustment for resource with unknown API discovery"
+                    );
+                    scope_cache.insert(key.gvk.clone(), false);
+                    adjusted.insert(key.clone(), *count);
+                    continue;
+                }
+                Err(err) => return Err(err),
+            };
             scope_cache.insert(key.gvk.clone(), discovered);
             discovered
         };
@@ -130,6 +155,18 @@ pub async fn adjust_duplicate_keys_for_namespace_resolution(
     }
 
     Ok(adjusted)
+}
+
+fn format_api_version(gvk: &GroupVersionKind) -> String {
+    if gvk.group.is_empty() {
+        gvk.version.clone()
+    } else {
+        format!("{}/{}", gvk.group, gvk.version)
+    }
+}
+
+fn is_api_resource_not_found_error(err: &NylError) -> bool {
+    matches!(err, NylError::Config(message) if message.starts_with("API resource not found for "))
 }
 
 fn set_manifest_namespace(manifest: &mut Value, namespace: &str) -> Result<()> {

--- a/nyl/src/cli/namespace_resolution.rs
+++ b/nyl/src/cli/namespace_resolution.rs
@@ -183,6 +183,7 @@ fn set_manifest_namespace(manifest: &mut Value, namespace: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::API_RESOURCE_NOT_FOUND_PREFIX;
     use crate::kubernetes::{ApplyOutcome, GroupVersionKind, MockKubeClient};
     use async_trait::async_trait;
     use kube::api::DynamicObject;
@@ -312,7 +313,7 @@ mod tests {
                 *counts.entry(gvk.clone()).or_insert(0) += 1;
             }
             Err(NylError::Config(format!(
-                "API resource not found for {}/{}",
+                "{API_RESOURCE_NOT_FOUND_PREFIX}{}/{}",
                 if gvk.group.is_empty() {
                     gvk.version.clone()
                 } else {

--- a/nyl/src/cli/namespace_resolution.rs
+++ b/nyl/src/cli/namespace_resolution.rs
@@ -39,7 +39,7 @@ pub async fn resolve_manifest_namespaces(
         } else {
             let discovered = match client.is_namespaced(&key.gvk).await {
                 Ok(v) => v,
-                Err(err) if is_api_resource_not_found_error(&err) => {
+                Err(err) if err.is_api_resource_not_found_error() => {
                     tracing::warn!(
                         api_version = %format_api_version(&key.gvk),
                         kind = %key.gvk.kind,
@@ -115,7 +115,7 @@ pub async fn adjust_duplicate_keys_for_namespace_resolution(
         } else {
             let discovered = match client.is_namespaced(&key.gvk).await {
                 Ok(v) => v,
-                Err(err) if is_api_resource_not_found_error(&err) => {
+                Err(err) if err.is_api_resource_not_found_error() => {
                     tracing::warn!(
                         api_version = %format_api_version(&key.gvk),
                         kind = %key.gvk.kind,
@@ -165,10 +165,6 @@ fn format_api_version(gvk: &GroupVersionKind) -> String {
     }
 }
 
-fn is_api_resource_not_found_error(err: &NylError) -> bool {
-    matches!(err, NylError::Config(message) if message.starts_with("API resource not found for "))
-}
-
 fn set_manifest_namespace(manifest: &mut Value, namespace: &str) -> Result<()> {
     let root = manifest
         .as_object_mut()
@@ -208,6 +204,24 @@ mod tests {
 
         fn is_namespaced_call_count(&self, gvk: &GroupVersionKind) -> usize {
             self.is_namespaced_calls.lock().unwrap().get(gvk).copied().unwrap_or(0)
+        }
+    }
+
+    struct ErroringKubeClient {
+        default_namespace: String,
+        call_counts: Arc<Mutex<HashMap<GroupVersionKind, usize>>>,
+    }
+
+    impl ErroringKubeClient {
+        fn new(default_namespace: &str) -> Self {
+            Self {
+                default_namespace: default_namespace.to_string(),
+                call_counts: Arc::new(Mutex::new(HashMap::new())),
+            }
+        }
+
+        fn call_count(&self, gvk: &GroupVersionKind) -> usize {
+            self.call_counts.lock().unwrap().get(gvk).copied().unwrap_or(0)
         }
     }
 
@@ -261,6 +275,67 @@ mod tests {
             field_manager: &str,
         ) -> Result<DynamicObject> {
             self.inner.get_normalized_resource(resource, field_manager).await
+        }
+    }
+
+    #[async_trait]
+    impl KubeClient for ErroringKubeClient {
+        async fn get_resource(
+            &self,
+            _gvk: &GroupVersionKind,
+            _namespace: Option<&str>,
+            _name: &str,
+        ) -> Result<Option<DynamicObject>> {
+            Ok(None)
+        }
+
+        async fn apply_resource(
+            &self,
+            _resource: &DynamicObject,
+            _field_manager: &str,
+            _dry_run: bool,
+        ) -> Result<ApplyOutcome> {
+            Err(NylError::Other("not used in this test".to_string()))
+        }
+
+        async fn get_server_version(&self) -> Result<String> {
+            Ok("1.30.0".to_string())
+        }
+
+        async fn get_api_versions(&self) -> Result<Vec<String>> {
+            Ok(vec![])
+        }
+
+        async fn is_namespaced(&self, gvk: &GroupVersionKind) -> Result<bool> {
+            {
+                let mut counts = self.call_counts.lock().unwrap();
+                *counts.entry(gvk.clone()).or_insert(0) += 1;
+            }
+            Err(NylError::Config(format!(
+                "API resource not found for {}/{}",
+                if gvk.group.is_empty() {
+                    gvk.version.clone()
+                } else {
+                    format!("{}/{}", gvk.group, gvk.version)
+                },
+                gvk.kind
+            )))
+        }
+
+        fn default_namespace(&self) -> &str {
+            &self.default_namespace
+        }
+
+        async fn delete_resource(&self, _gvk: &GroupVersionKind, _namespace: Option<&str>, _name: &str) -> Result<()> {
+            Ok(())
+        }
+
+        async fn get_normalized_resource(
+            &self,
+            resource: &DynamicObject,
+            _field_manager: &str,
+        ) -> Result<DynamicObject> {
+            Ok(resource.clone())
         }
     }
 
@@ -456,5 +531,69 @@ mod tests {
             .unwrap();
 
         assert_eq!(client.is_namespaced_call_count(&key.gvk), 1);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_manifest_namespaces_skips_api_not_found_and_caches() {
+        let client = ErroringKubeClient::new("ctx-default");
+        let gvk = GroupVersionKind {
+            group: "kyverno.io".to_string(),
+            version: "v1".to_string(),
+            kind: "ClusterPolicy".to_string(),
+        };
+        let mut manifests = vec![
+            json!({
+                "apiVersion": "kyverno.io/v1",
+                "kind": "ClusterPolicy",
+                "metadata": {"name": "policy-1"}
+            }),
+            json!({
+                "apiVersion": "kyverno.io/v1",
+                "kind": "ClusterPolicy",
+                "metadata": {"name": "policy-2"}
+            }),
+        ];
+
+        let resolved = resolve_manifest_namespaces(&client, &mut manifests, Some("release"))
+            .await
+            .unwrap();
+
+        assert_eq!(resolved, 0);
+        assert_eq!(client.call_count(&gvk), 1);
+    }
+
+    #[tokio::test]
+    async fn test_adjust_duplicate_keys_skips_api_not_found_and_caches() {
+        let client = ErroringKubeClient::new("ctx-default");
+        let gvk = GroupVersionKind {
+            group: "kyverno.io".to_string(),
+            version: "v1".to_string(),
+            kind: "ClusterPolicy".to_string(),
+        };
+
+        let mut duplicates = HashMap::new();
+        duplicates.insert(
+            ResourceKey {
+                gvk: gvk.clone(),
+                namespace: None,
+                name: "policy-1".to_string(),
+            },
+            2,
+        );
+        duplicates.insert(
+            ResourceKey {
+                gvk: gvk.clone(),
+                namespace: None,
+                name: "policy-2".to_string(),
+            },
+            1,
+        );
+
+        let adjusted = adjust_duplicate_keys_for_namespace_resolution(&client, &duplicates, Some("release"))
+            .await
+            .unwrap();
+
+        assert_eq!(adjusted.len(), 2);
+        assert_eq!(client.call_count(&gvk), 1);
     }
 }

--- a/nyl/src/error.rs
+++ b/nyl/src/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-pub const API_RESOURCE_NOT_FOUND_PREFIX: &str = "API resource not found for ";
+pub(crate) const API_RESOURCE_NOT_FOUND_PREFIX: &str = "API resource not found for ";
 
 /// Main error type for nyl
 #[derive(Error, Debug)]

--- a/nyl/src/error.rs
+++ b/nyl/src/error.rs
@@ -215,9 +215,7 @@ mod tests {
 
     #[test]
     fn test_is_api_resource_not_found_error() {
-        let err = NylError::Config(format!(
-            "{API_RESOURCE_NOT_FOUND_PREFIX}kyverno.io/v1/ClusterPolicy"
-        ));
+        let err = NylError::Config(format!("{API_RESOURCE_NOT_FOUND_PREFIX}kyverno.io/v1/ClusterPolicy"));
         assert!(err.is_api_resource_not_found_error());
 
         let other = NylError::Config("some other config error".to_string());

--- a/nyl/src/error.rs
+++ b/nyl/src/error.rs
@@ -1,5 +1,7 @@
 use thiserror::Error;
 
+pub const API_RESOURCE_NOT_FOUND_PREFIX: &str = "API resource not found for ";
+
 /// Main error type for nyl
 #[derive(Error, Debug)]
 pub enum NylError {
@@ -114,6 +116,11 @@ impl NylError {
     pub fn is_git_error(&self) -> bool {
         matches!(self, NylError::Git(_))
     }
+
+    /// Returns true if this is an API discovery miss for a specific GVK.
+    pub fn is_api_resource_not_found_error(&self) -> bool {
+        matches!(self, NylError::Config(message) if message.starts_with(API_RESOURCE_NOT_FOUND_PREFIX))
+    }
 }
 
 impl From<kube::Error> for NylError {
@@ -204,6 +211,15 @@ mod tests {
         let display = format!("{}", helm_err);
         assert!(display.contains("Hint:"));
         assert!(display.contains("helm version"));
+    }
+
+    #[test]
+    fn test_is_api_resource_not_found_error() {
+        let err = NylError::Config("API resource not found for kyverno.io/v1/ClusterPolicy".to_string());
+        assert!(err.is_api_resource_not_found_error());
+
+        let other = NylError::Config("some other config error".to_string());
+        assert!(!other.is_api_resource_not_found_error());
     }
 
     #[test]

--- a/nyl/src/error.rs
+++ b/nyl/src/error.rs
@@ -215,7 +215,9 @@ mod tests {
 
     #[test]
     fn test_is_api_resource_not_found_error() {
-        let err = NylError::Config("API resource not found for kyverno.io/v1/ClusterPolicy".to_string());
+        let err = NylError::Config(format!(
+            "{API_RESOURCE_NOT_FOUND_PREFIX}kyverno.io/v1/ClusterPolicy"
+        ));
         assert!(err.is_api_resource_not_found_error());
 
         let other = NylError::Config("some other config error".to_string());

--- a/nyl/src/kubernetes/client.rs
+++ b/nyl/src/kubernetes/client.rs
@@ -224,7 +224,7 @@ impl KubeRsClient {
             return Ok(None);
         }
 
-        if let Some(cached) = self.crd_scope_cache.lock().unwrap().get(gvk).cloned() {
+        if let Some(cached) = self.crd_scope_cache.lock().unwrap().get(gvk).copied() {
             return Ok(cached);
         }
 

--- a/nyl/src/kubernetes/client.rs
+++ b/nyl/src/kubernetes/client.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use kube::{
-    api::{Api, DynamicObject, Patch, PatchParams},
+    api::{Api, DynamicObject, ListParams, Patch, PatchParams},
     discovery::{ApiCapabilities, ApiResource, Discovery, Scope},
     Client, ResourceExt,
 };
@@ -237,7 +237,7 @@ impl KubeRsClient {
         }
 
         let crd_api: Api<DynamicObject> = Api::all_with(self.client.clone(), &crd_api_resource());
-        let crds = crd_api.list(&Default::default()).await?;
+        let crds = crd_api.list(&ListParams::default()).await?;
 
         for crd in crds.items {
             if let Some(namespaced) = scope_from_crd_for_gvk(&crd, gvk) {

--- a/nyl/src/kubernetes/client.rs
+++ b/nyl/src/kubernetes/client.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use crate::{
+    error::API_RESOURCE_NOT_FOUND_PREFIX,
     kubernetes::resource::{ApplyOutcome, GroupVersionKind, ResourceKey},
     profiles::{KubeconfigSource, Profile},
     NylError, Result,
@@ -213,7 +214,7 @@ impl KubeRsClient {
         };
 
         Err(NylError::Config(format!(
-            "API resource not found for {}/{}{}",
+            "{API_RESOURCE_NOT_FOUND_PREFIX}{}/{}{}",
             group_version, gvk.kind, versions_hint
         )))
     }
@@ -541,8 +542,8 @@ impl MockKubeClient {
         overrides.insert(kind.to_string(), namespaced);
     }
 
-    fn default_scope_for_kind(kind: &str) -> bool {
-        !is_known_cluster_scoped_kind(kind)
+    fn default_scope_for_gvk(gvk: &GroupVersionKind) -> bool {
+        !is_known_cluster_scoped_gvk(gvk)
     }
 }
 
@@ -726,7 +727,7 @@ impl KubeClient for MockKubeClient {
         Ok(overrides
             .get(&gvk.kind)
             .copied()
-            .unwrap_or_else(|| Self::default_scope_for_kind(&gvk.kind)))
+            .unwrap_or_else(|| Self::default_scope_for_gvk(gvk)))
     }
 
     fn default_namespace(&self) -> &str {

--- a/nyl/src/kubernetes/client.rs
+++ b/nyl/src/kubernetes/client.rs
@@ -188,31 +188,20 @@ impl KubeRsClient {
             return Ok((ar.clone(), caps.clone()));
         }
 
-        if let Some((ar, caps)) = self.find_api_resource_by_group_kind(gvk) {
-            tracing::debug!(
-                requested_group = %gvk.group,
-                requested_version = %gvk.version,
-                requested_kind = %gvk.kind,
-                resolved_group = %ar.group,
-                resolved_version = %ar.version,
-                resolved_kind = %ar.kind,
-                "Falling back to discovered API resource with matching group/kind but different version"
-            );
-            return Ok((ar, caps));
-        }
-
         let group_version = if gvk.group.is_empty() {
             gvk.version.clone()
         } else {
             format!("{}/{}", gvk.group, gvk.version)
         };
 
-        let available_versions: Vec<String> = self
+        let mut available_versions: Vec<String> = self
             .api_resources
             .keys()
             .filter(|known| known.group == gvk.group && known.kind == gvk.kind)
             .map(|known| known.version.clone())
             .collect();
+        available_versions.sort();
+        available_versions.dedup();
 
         let versions_hint = if available_versions.is_empty() {
             String::new()
@@ -226,10 +215,6 @@ impl KubeRsClient {
         )))
     }
 
-    fn find_api_resource_by_group_kind(&self, gvk: &GroupVersionKind) -> Option<(ApiResource, ApiCapabilities)> {
-        find_api_resource_by_group_kind_in_index(&self.api_resources, gvk)
-    }
-
     async fn try_resolve_scope_from_crd(&self, gvk: &GroupVersionKind) -> Result<Option<bool>> {
         // Core API resources cannot be represented by CRDs.
         if gvk.group.is_empty() {
@@ -237,7 +222,18 @@ impl KubeRsClient {
         }
 
         let crd_api: Api<DynamicObject> = Api::all_with(self.client.clone(), &crd_api_resource());
-        let crds = crd_api.list(&ListParams::default()).await?;
+        let crds = match crd_api.list(&ListParams::default()).await {
+            Ok(crds) => crds,
+            Err(kube::Error::Api(err)) if err.code == 403 || err.code == 404 => {
+                tracing::debug!(
+                    code = err.code,
+                    message = %err.message,
+                    "Unable to list CRDs for scope fallback; proceeding without CRD fallback"
+                );
+                return Ok(None);
+            }
+            Err(err) => return Err(err.into()),
+        };
 
         for crd in crds.items {
             if let Some(namespaced) = scope_from_crd_for_gvk(&crd, gvk) {
@@ -247,16 +243,6 @@ impl KubeRsClient {
 
         Ok(None)
     }
-}
-
-fn find_api_resource_by_group_kind_in_index(
-    api_resources: &HashMap<GroupVersionKind, (ApiResource, ApiCapabilities)>,
-    gvk: &GroupVersionKind,
-) -> Option<(ApiResource, ApiCapabilities)> {
-    api_resources
-        .iter()
-        .find(|(known, _)| known.group == gvk.group && known.kind == gvk.kind)
-        .map(|(_, value)| value.clone())
 }
 
 #[async_trait]
@@ -420,15 +406,25 @@ impl KubeClient for KubeRsClient {
     }
 
     async fn is_namespaced(&self, gvk: &GroupVersionKind) -> Result<bool> {
-        if is_known_cluster_scoped_kind(&gvk.kind) {
+        if is_known_cluster_scoped_gvk(gvk) {
             return Ok(false);
         }
         match self.discover_api_resource(gvk) {
             Ok((_ar, caps)) => Ok(caps.scope == Scope::Namespaced),
             Err(err) => {
-                if is_api_resource_not_found_config_error(&err) {
-                    if let Some(namespaced) = self.try_resolve_scope_from_crd(gvk).await? {
-                        return Ok(namespaced);
+                if err.is_api_resource_not_found_error() {
+                    match self.try_resolve_scope_from_crd(gvk).await {
+                        Ok(Some(namespaced)) => return Ok(namespaced),
+                        Ok(None) => {}
+                        Err(crd_err) => {
+                            tracing::debug!(
+                                requested_group = %gvk.group,
+                                requested_version = %gvk.version,
+                                requested_kind = %gvk.kind,
+                                error = %crd_err,
+                                "Failed CRD scope fallback; preserving original API resource discovery error"
+                            );
+                        }
                     }
                 }
                 Err(err)
@@ -556,6 +552,23 @@ fn is_known_cluster_scoped_kind(kind: &str) -> bool {
     )
 }
 
+fn is_known_cluster_scoped_gvk(gvk: &GroupVersionKind) -> bool {
+    match gvk.group.as_str() {
+        "" => is_known_cluster_scoped_kind(&gvk.kind),
+        "rbac.authorization.k8s.io" => matches!(gvk.kind.as_str(), "ClusterRole" | "ClusterRoleBinding"),
+        "storage.k8s.io" => matches!(gvk.kind.as_str(), "StorageClass" | "VolumeAttachment"),
+        "admissionregistration.k8s.io" => {
+            matches!(
+                gvk.kind.as_str(),
+                "MutatingWebhookConfiguration" | "ValidatingWebhookConfiguration"
+            )
+        }
+        "apiregistration.k8s.io" => matches!(gvk.kind.as_str(), "APIService"),
+        "apiextensions.k8s.io" => matches!(gvk.kind.as_str(), "CustomResourceDefinition"),
+        _ => false,
+    }
+}
+
 fn crd_api_resource() -> ApiResource {
     ApiResource {
         group: "apiextensions.k8s.io".to_string(),
@@ -593,10 +606,6 @@ fn scope_from_crd_for_gvk(crd: &DynamicObject, gvk: &GroupVersionKind) -> Option
         "Cluster" => Some(false),
         _ => None,
     }
-}
-
-fn is_api_resource_not_found_config_error(err: &NylError) -> bool {
-    matches!(err, NylError::Config(message) if message.starts_with("API resource not found for "))
 }
 
 impl Default for MockKubeClient {
@@ -964,39 +973,20 @@ mod tests {
     }
 
     #[test]
-    fn test_find_api_resource_by_group_kind_falls_back_to_other_version() {
-        let mut api_resources = HashMap::new();
-
-        let known_gvk = GroupVersionKind {
-            group: "kyverno.io".to_string(),
-            version: "v2".to_string(),
-            kind: "ClusterPolicy".to_string(),
-        };
-        let ar = ApiResource {
-            group: "kyverno.io".to_string(),
-            version: "v2".to_string(),
-            api_version: "kyverno.io/v2".to_string(),
-            kind: "ClusterPolicy".to_string(),
-            plural: "clusterpolicies".to_string(),
-        };
-        let caps = ApiCapabilities {
-            scope: Scope::Cluster,
-            subresources: vec![],
-            operations: vec![],
-        };
-        api_resources.insert(known_gvk, (ar.clone(), caps.clone()));
-
-        let requested = GroupVersionKind {
-            group: "kyverno.io".to_string(),
+    fn test_is_known_cluster_scoped_gvk_respects_group() {
+        let built_in = GroupVersionKind {
+            group: String::new(),
             version: "v1".to_string(),
-            kind: "ClusterPolicy".to_string(),
+            kind: "Namespace".to_string(),
         };
+        assert!(is_known_cluster_scoped_gvk(&built_in));
 
-        let (resolved_ar, resolved_caps) =
-            find_api_resource_by_group_kind_in_index(&api_resources, &requested).unwrap();
-        assert_eq!(resolved_ar.version, "v2");
-        assert_eq!(resolved_ar.kind, "ClusterPolicy");
-        assert_eq!(resolved_caps.scope, Scope::Cluster);
+        let custom_same_kind = GroupVersionKind {
+            group: "example.com".to_string(),
+            version: "v1".to_string(),
+            kind: "Namespace".to_string(),
+        };
+        assert!(!is_known_cluster_scoped_gvk(&custom_same_kind));
     }
 
     #[test]

--- a/nyl/src/kubernetes/client.rs
+++ b/nyl/src/kubernetes/client.rs
@@ -62,6 +62,7 @@ pub struct KubeRsClient {
     client: Client,
     discovery: Arc<Discovery>,
     api_resources: HashMap<GroupVersionKind, (ApiResource, ApiCapabilities)>,
+    crd_scope_cache: Mutex<HashMap<GroupVersionKind, Option<bool>>>,
 }
 
 impl KubeRsClient {
@@ -151,6 +152,7 @@ impl KubeRsClient {
             client,
             discovery,
             api_resources,
+            crd_scope_cache: Mutex::new(HashMap::new()),
         })
     }
 
@@ -162,6 +164,7 @@ impl KubeRsClient {
             client,
             discovery,
             api_resources,
+            crd_scope_cache: Mutex::new(HashMap::new()),
         })
     }
 
@@ -221,6 +224,10 @@ impl KubeRsClient {
             return Ok(None);
         }
 
+        if let Some(cached) = self.crd_scope_cache.lock().unwrap().get(gvk).cloned() {
+            return Ok(cached);
+        }
+
         let crd_api: Api<DynamicObject> = Api::all_with(self.client.clone(), &crd_api_resource());
         let crds = match crd_api.list(&ListParams::default()).await {
             Ok(crds) => crds,
@@ -230,6 +237,7 @@ impl KubeRsClient {
                     message = %err.message,
                     "Unable to list CRDs for scope fallback; proceeding without CRD fallback"
                 );
+                self.crd_scope_cache.lock().unwrap().insert(gvk.clone(), None);
                 return Ok(None);
             }
             Err(err) => return Err(err.into()),
@@ -237,10 +245,15 @@ impl KubeRsClient {
 
         for crd in crds.items {
             if let Some(namespaced) = scope_from_crd_for_gvk(&crd, gvk) {
+                self.crd_scope_cache
+                    .lock()
+                    .unwrap()
+                    .insert(gvk.clone(), Some(namespaced));
                 return Ok(Some(namespaced));
             }
         }
 
+        self.crd_scope_cache.lock().unwrap().insert(gvk.clone(), None);
         Ok(None)
     }
 }

--- a/nyl/src/kubernetes/client.rs
+++ b/nyl/src/kubernetes/client.rs
@@ -188,17 +188,75 @@ impl KubeRsClient {
             return Ok((ar.clone(), caps.clone()));
         }
 
+        if let Some((ar, caps)) = self.find_api_resource_by_group_kind(gvk) {
+            tracing::debug!(
+                requested_group = %gvk.group,
+                requested_version = %gvk.version,
+                requested_kind = %gvk.kind,
+                resolved_group = %ar.group,
+                resolved_version = %ar.version,
+                resolved_kind = %ar.kind,
+                "Falling back to discovered API resource with matching group/kind but different version"
+            );
+            return Ok((ar, caps));
+        }
+
         let group_version = if gvk.group.is_empty() {
             gvk.version.clone()
         } else {
             format!("{}/{}", gvk.group, gvk.version)
         };
 
+        let available_versions: Vec<String> = self
+            .api_resources
+            .keys()
+            .filter(|known| known.group == gvk.group && known.kind == gvk.kind)
+            .map(|known| known.version.clone())
+            .collect();
+
+        let versions_hint = if available_versions.is_empty() {
+            String::new()
+        } else {
+            format!(" (available versions for this kind: {})", available_versions.join(", "))
+        };
+
         Err(NylError::Config(format!(
-            "API resource not found for {}/{}",
-            group_version, gvk.kind
+            "API resource not found for {}/{}{}",
+            group_version, gvk.kind, versions_hint
         )))
     }
+
+    fn find_api_resource_by_group_kind(&self, gvk: &GroupVersionKind) -> Option<(ApiResource, ApiCapabilities)> {
+        find_api_resource_by_group_kind_in_index(&self.api_resources, gvk)
+    }
+
+    async fn try_resolve_scope_from_crd(&self, gvk: &GroupVersionKind) -> Result<Option<bool>> {
+        // Core API resources cannot be represented by CRDs.
+        if gvk.group.is_empty() {
+            return Ok(None);
+        }
+
+        let crd_api: Api<DynamicObject> = Api::all_with(self.client.clone(), &crd_api_resource());
+        let crds = crd_api.list(&Default::default()).await?;
+
+        for crd in crds.items {
+            if let Some(namespaced) = scope_from_crd_for_gvk(&crd, gvk) {
+                return Ok(Some(namespaced));
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+fn find_api_resource_by_group_kind_in_index(
+    api_resources: &HashMap<GroupVersionKind, (ApiResource, ApiCapabilities)>,
+    gvk: &GroupVersionKind,
+) -> Option<(ApiResource, ApiCapabilities)> {
+    api_resources
+        .iter()
+        .find(|(known, _)| known.group == gvk.group && known.kind == gvk.kind)
+        .map(|(_, value)| value.clone())
 }
 
 #[async_trait]
@@ -362,8 +420,20 @@ impl KubeClient for KubeRsClient {
     }
 
     async fn is_namespaced(&self, gvk: &GroupVersionKind) -> Result<bool> {
-        let (_ar, caps) = self.discover_api_resource(gvk)?;
-        Ok(caps.scope == Scope::Namespaced)
+        if is_known_cluster_scoped_kind(&gvk.kind) {
+            return Ok(false);
+        }
+        match self.discover_api_resource(gvk) {
+            Ok((_ar, caps)) => Ok(caps.scope == Scope::Namespaced),
+            Err(err) => {
+                if is_api_resource_not_found_config_error(&err) {
+                    if let Some(namespaced) = self.try_resolve_scope_from_crd(gvk).await? {
+                        return Ok(namespaced);
+                    }
+                }
+                Err(err)
+            }
+        }
     }
 
     fn default_namespace(&self) -> &str {
@@ -463,24 +533,70 @@ impl MockKubeClient {
     }
 
     fn default_scope_for_kind(kind: &str) -> bool {
-        // Most resources are namespaced. Explicitly list common cluster-scoped kinds.
-        !matches!(
-            kind,
-            "APIService"
-                | "ClusterRole"
-                | "ClusterRoleBinding"
-                | "CustomResourceDefinition"
-                | "MutatingWebhookConfiguration"
-                | "Namespace"
-                | "Node"
-                | "PersistentVolume"
-                | "PriorityClass"
-                | "RuntimeClass"
-                | "StorageClass"
-                | "ValidatingWebhookConfiguration"
-                | "VolumeAttachment"
-        )
+        !is_known_cluster_scoped_kind(kind)
     }
+}
+
+fn is_known_cluster_scoped_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "APIService"
+            | "ClusterRole"
+            | "ClusterRoleBinding"
+            | "CustomResourceDefinition"
+            | "MutatingWebhookConfiguration"
+            | "Namespace"
+            | "Node"
+            | "PersistentVolume"
+            | "PriorityClass"
+            | "RuntimeClass"
+            | "StorageClass"
+            | "ValidatingWebhookConfiguration"
+            | "VolumeAttachment"
+    )
+}
+
+fn crd_api_resource() -> ApiResource {
+    ApiResource {
+        group: "apiextensions.k8s.io".to_string(),
+        version: "v1".to_string(),
+        api_version: "apiextensions.k8s.io/v1".to_string(),
+        kind: "CustomResourceDefinition".to_string(),
+        plural: "customresourcedefinitions".to_string(),
+    }
+}
+
+fn scope_from_crd_for_gvk(crd: &DynamicObject, gvk: &GroupVersionKind) -> Option<bool> {
+    let value = serde_json::to_value(crd).ok()?;
+    let spec = value.get("spec")?;
+    let group = spec.get("group")?.as_str()?;
+    let kind = spec.get("names")?.get("kind")?.as_str()?;
+    let scope = spec.get("scope")?.as_str()?;
+    let versions = spec.get("versions")?.as_array()?;
+
+    if group != gvk.group || kind != gvk.kind {
+        return None;
+    }
+
+    // Mirror Kubernetes behavior: only served versions are requestable.
+    let version_is_served = versions.iter().any(|v| {
+        let name = v.get("name").and_then(serde_json::Value::as_str);
+        let served = v.get("served").and_then(serde_json::Value::as_bool).unwrap_or(false);
+        name == Some(gvk.version.as_str()) && served
+    });
+    if !version_is_served {
+        return None;
+    }
+
+    match scope {
+        "Namespaced" => Some(true),
+        "Cluster" => Some(false),
+        _ => None,
+    }
+}
+
+fn is_api_resource_not_found_config_error(err: &NylError) -> bool {
+    matches!(err, NylError::Config(message) if message.starts_with("API resource not found for "))
 }
 
 impl Default for MockKubeClient {
@@ -845,5 +961,146 @@ mod tests {
     fn test_mock_client_default_namespace() {
         let client = MockKubeClient::with_default_namespace("custom");
         assert_eq!(client.default_namespace(), "custom");
+    }
+
+    #[test]
+    fn test_find_api_resource_by_group_kind_falls_back_to_other_version() {
+        let mut api_resources = HashMap::new();
+
+        let known_gvk = GroupVersionKind {
+            group: "kyverno.io".to_string(),
+            version: "v2".to_string(),
+            kind: "ClusterPolicy".to_string(),
+        };
+        let ar = ApiResource {
+            group: "kyverno.io".to_string(),
+            version: "v2".to_string(),
+            api_version: "kyverno.io/v2".to_string(),
+            kind: "ClusterPolicy".to_string(),
+            plural: "clusterpolicies".to_string(),
+        };
+        let caps = ApiCapabilities {
+            scope: Scope::Cluster,
+            subresources: vec![],
+            operations: vec![],
+        };
+        api_resources.insert(known_gvk, (ar.clone(), caps.clone()));
+
+        let requested = GroupVersionKind {
+            group: "kyverno.io".to_string(),
+            version: "v1".to_string(),
+            kind: "ClusterPolicy".to_string(),
+        };
+
+        let (resolved_ar, resolved_caps) =
+            find_api_resource_by_group_kind_in_index(&api_resources, &requested).unwrap();
+        assert_eq!(resolved_ar.version, "v2");
+        assert_eq!(resolved_ar.kind, "ClusterPolicy");
+        assert_eq!(resolved_caps.scope, Scope::Cluster);
+    }
+
+    #[test]
+    fn test_scope_from_crd_for_gvk_cluster() {
+        let crd: DynamicObject = serde_json::from_value(json!({
+            "apiVersion": "apiextensions.k8s.io/v1",
+            "kind": "CustomResourceDefinition",
+            "metadata": {"name": "clusterpolicies.kyverno.io"},
+            "spec": {
+                "group": "kyverno.io",
+                "names": {"kind": "ClusterPolicy"},
+                "scope": "Cluster",
+                "versions": [
+                    {"name": "v1", "served": true}
+                ]
+            }
+        }))
+        .unwrap();
+
+        let gvk = GroupVersionKind {
+            group: "kyverno.io".to_string(),
+            version: "v1".to_string(),
+            kind: "ClusterPolicy".to_string(),
+        };
+
+        assert_eq!(scope_from_crd_for_gvk(&crd, &gvk), Some(false));
+    }
+
+    #[test]
+    fn test_scope_from_crd_for_gvk_namespaced() {
+        let crd: DynamicObject = serde_json::from_value(json!({
+            "apiVersion": "apiextensions.k8s.io/v1",
+            "kind": "CustomResourceDefinition",
+            "metadata": {"name": "widgets.example.com"},
+            "spec": {
+                "group": "example.com",
+                "names": {"kind": "Widget"},
+                "scope": "Namespaced",
+                "versions": [
+                    {"name": "v1", "served": true}
+                ]
+            }
+        }))
+        .unwrap();
+
+        let gvk = GroupVersionKind {
+            group: "example.com".to_string(),
+            version: "v1".to_string(),
+            kind: "Widget".to_string(),
+        };
+
+        assert_eq!(scope_from_crd_for_gvk(&crd, &gvk), Some(true));
+    }
+
+    #[test]
+    fn test_scope_from_crd_for_gvk_rejects_unserved_version() {
+        let crd: DynamicObject = serde_json::from_value(json!({
+            "apiVersion": "apiextensions.k8s.io/v1",
+            "kind": "CustomResourceDefinition",
+            "metadata": {"name": "clusterpolicies.kyverno.io"},
+            "spec": {
+                "group": "kyverno.io",
+                "names": {"kind": "ClusterPolicy"},
+                "scope": "Cluster",
+                "versions": [
+                    {"name": "v1", "served": false},
+                    {"name": "v2beta1", "served": true}
+                ]
+            }
+        }))
+        .unwrap();
+
+        let gvk = GroupVersionKind {
+            group: "kyverno.io".to_string(),
+            version: "v1".to_string(),
+            kind: "ClusterPolicy".to_string(),
+        };
+
+        assert_eq!(scope_from_crd_for_gvk(&crd, &gvk), None);
+    }
+
+    #[test]
+    fn test_scope_from_crd_for_gvk_rejects_missing_version() {
+        let crd: DynamicObject = serde_json::from_value(json!({
+            "apiVersion": "apiextensions.k8s.io/v1",
+            "kind": "CustomResourceDefinition",
+            "metadata": {"name": "clusterpolicies.kyverno.io"},
+            "spec": {
+                "group": "kyverno.io",
+                "names": {"kind": "ClusterPolicy"},
+                "scope": "Cluster",
+                "versions": [
+                    {"name": "v2beta1", "served": true}
+                ]
+            }
+        }))
+        .unwrap();
+
+        let gvk = GroupVersionKind {
+            group: "kyverno.io".to_string(),
+            version: "v1".to_string(),
+            kind: "ClusterPolicy".to_string(),
+        };
+
+        assert_eq!(scope_from_crd_for_gvk(&crd, &gvk), None);
     }
 }


### PR DESCRIPTION
## Summary
- make namespace resolution resilient when API discovery cannot resolve a rendered GVK
- add CRD-based scope fallback in KubeRsClient::is_namespaced() for custom resources
- only trust CRD fallback when the requested version is explicitly served=true, matching Kubernetes behavior
- keep cluster-scoped built-in kind handling centralized for mock and real client scope checks

## Details
- discover_api_resource() now surfaces available versions for the same group+kind in error text
- namespace_resolution now handles API resource not found from discovery explicitly instead of failing immediately
- CRD scope inference reads spec.group, spec.names.kind, spec.scope, and spec.versions[*].served

## Tests
- cargo test -p nyl kubernetes::client -- --nocapture
- cargo test -p nyl cli::namespace_resolution -- --nocapture