### PR TITLE
feat: add RemoteManifest resource support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +285,12 @@ dependencies = [
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -359,6 +387,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +409,16 @@ checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -668,6 +715,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,7 +751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -776,6 +829,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1092,7 +1151,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1307,7 +1365,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1330,6 +1388,28 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
@@ -1683,7 +1763,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1720,6 +1800,7 @@ dependencies = [
  "predicates",
  "regex",
  "reqwest",
+ "rustls",
  "schemars",
  "serde",
  "serde_json",
@@ -2041,6 +2122,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -2067,7 +2149,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2215,15 +2297,13 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2237,9 +2317,7 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
+ "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -2250,7 +2328,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2283,7 +2360,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2292,6 +2369,7 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2346,11 +2424,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs 0.8.3",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.5.1",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2549,18 +2655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2747,7 +2841,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3305,10 +3399,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
+name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3335,7 +3429,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3405,6 +3499,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -3446,6 +3549,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3498,6 +3616,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -3516,6 +3640,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -3531,6 +3661,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3564,6 +3700,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -3579,6 +3721,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3600,6 +3748,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -3615,6 +3769,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "getrandom 0.2.17",
  "instant",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -269,6 +269,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -865,8 +871,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -876,9 +884,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1082,6 +1092,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1103,6 +1114,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -1110,7 +1122,9 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1270,6 +1284,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,8 +1448,8 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",
- "tower",
- "tower-http",
+ "tower 0.4.13",
+ "tower-http 0.5.2",
  "tracing",
 ]
 
@@ -1584,6 +1614,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,6 +1719,7 @@ dependencies = [
  "minijinja",
  "predicates",
  "regex",
+ "reqwest",
  "schemars",
  "serde",
  "serde_json",
@@ -1979,6 +2016,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2000,8 +2092,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2011,7 +2113,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2021,6 +2133,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2093,6 +2214,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.5.3",
+ "tower-http 0.6.8",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,6 +2266,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -2174,6 +2341,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2381,6 +2549,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2538,6 +2718,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2645,6 +2834,21 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2757,6 +2961,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-http"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2773,6 +2992,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -3002,6 +3239,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3041,6 +3292,25 @@ checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/nyl/Cargo.toml
+++ b/nyl/Cargo.toml
@@ -61,6 +61,7 @@ chrono = { version = "0.4", features = ["serde"] }
 # Git
 git2 = { version = "0.19", features = ["vendored-libgit2", "vendored-openssl"] }
 regex = "1.10"
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 
 # Diff and output
 colored = "2.1"

--- a/nyl/Cargo.toml
+++ b/nyl/Cargo.toml
@@ -37,6 +37,7 @@ schemars = "0.8"
 # Kubernetes
 kube = { version = "0.95", features = ["client", "runtime", "derive"] }
 k8s-openapi = { version = "0.23", features = ["latest"] }
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
 
 # Error handling
 thiserror = "2.0"
@@ -61,7 +62,7 @@ chrono = { version = "0.4", features = ["serde"] }
 # Git
 git2 = { version = "0.19", features = ["vendored-libgit2", "vendored-openssl"] }
 regex = "1.10"
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+reqwest = { version = "0.13.2", default-features = false, features = ["rustls"] }
 
 # Diff and output
 colored = "2.1"

--- a/nyl/book/src/SUMMARY.md
+++ b/nyl/book/src/SUMMARY.md
@@ -35,6 +35,7 @@
 - [Resources](./reference/resources.md)
   - [Component](./reference/resources/component.md)
   - [HelmChart](./reference/resources/helmchart.md)
+  - [RemoteManifest](./reference/resources/remote-manifest.md)
   - [NylRelease](./reference/resources/nyl-release.md)
   - [ApplicationGenerator](./reference/resources/application-generator.md)
 - [Kyverno Policies](./reference/kyverno-policies.md)

--- a/nyl/book/src/commands/rendering-pipeline.md
+++ b/nyl/book/src/commands/rendering-pipeline.md
@@ -8,7 +8,7 @@
 2. Load secrets and build the template context.
 3. Load the input manifest file and render Jinja templates.
 4. Apply `--only-source-kind` filtering on top-level input resources (before expansion).
-5. Expand resources recursively (`HelmChart`, `Component`, aliases) with `--max-depth`.
+5. Expand resources recursively (`HelmChart`, `Component`, `RemoteManifest`, aliases) with `--max-depth`.
 6. Process `ApplicationGenerator` resources into Argo CD `Application` manifests.
 7. Apply Kyverno policies (Global scope currently supported).
 8. Deduplicate final manifests (last occurrence wins).

--- a/nyl/book/src/reference/resources.md
+++ b/nyl/book/src/reference/resources.md
@@ -9,6 +9,7 @@ Nyl provides Kubernetes-style custom resources for declarative configuration and
 - **[NylRelease](./resources/nyl-release.md)**: Defines release metadata (name, namespace) for deployments
 - **[Component](./resources/component.md)**: Compact chart-backed resource using dynamic `kind` lookup
 - **[HelmChart](./resources/helmchart.md)**: Declarative Helm chart deployment with templating support
+- **[RemoteManifest](./resources/remote-manifest.md)**: Fetch and include manifests from a remote HTTPS URL
 
 ### ArgoCD Resources
 
@@ -35,6 +36,7 @@ spec:
 ## API Versions
 
 - `nyl.niklasrosenstein.github.com/v1`: Core Nyl resources (NylRelease, HelmChart)
+  - Includes: `NylRelease`, `HelmChart`, `RemoteManifest`
 - `argocd.nyl.niklasrosenstein.github.com/v1`: ArgoCD integration resources (ApplicationGenerator)
 - `components.nyl.niklasrosenstein.github.com/v1`: Component resources (dynamic `kind` path/shortcut)
 
@@ -51,6 +53,7 @@ Nyl resources are processed based on their kind:
 - **NylRelease**: Extracted and removed from output (provides metadata only)
 - **Component**: Resolved to a chart reference and rendered via Helm, replaced with rendered manifests
 - **HelmChart**: Rendered using Helm templating, replaced with rendered manifests
+- **RemoteManifest**: Fetched via HTTPS and parsed into documents, then processed recursively
 - **ApplicationGenerator**: Processed to generate ArgoCD Applications, removed from output
 
 ## Multi-Document Files

--- a/nyl/book/src/reference/resources/remote-manifest.md
+++ b/nyl/book/src/reference/resources/remote-manifest.md
@@ -29,6 +29,7 @@ spec:
 - URL must use `https://`.
 - Fetching uses Nyl's native HTTPS client (no shell-out), with HTTPS-only redirect policy.
 - Request timeouts are enforced (connect: 5s, total: 30s).
+- Response size is limited to 30 MiB; larger payloads fail fast.
 - Content is parsed as YAML multi-document stream.
 - Parsed resources are processed recursively like local resources.
 - Remote content is not rendered as a Jinja template.

--- a/nyl/book/src/reference/resources/remote-manifest.md
+++ b/nyl/book/src/reference/resources/remote-manifest.md
@@ -27,6 +27,8 @@ spec:
 ## Behavior
 
 - URL must use `https://`.
+- Fetching uses Nyl's native HTTPS client (no shell-out), with HTTPS-only redirect policy.
+- Request timeouts are enforced (connect: 5s, total: 30s).
 - Content is parsed as YAML multi-document stream.
 - Parsed resources are processed recursively like local resources.
 - Remote content is not rendered as a Jinja template.

--- a/nyl/book/src/reference/resources/remote-manifest.md
+++ b/nyl/book/src/reference/resources/remote-manifest.md
@@ -31,7 +31,8 @@ spec:
 - Parsed resources are processed recursively like local resources.
 - Remote content is not rendered as a Jinja template.
 - When `spec.overrideNamespace: true`, remote manifests with `metadata.namespace` are rewritten to `RemoteManifest.metadata.namespace`.
-- Special case: for `ClusterRoleBinding` (`rbac.authorization.k8s.io/*`), `subjects[*].namespace` is also rewritten (ServiceAccount subjects are forced to the override namespace).
+- Special case: for `RoleBinding` and `ClusterRoleBinding` (`rbac.authorization.k8s.io/*`), `subjects[*].namespace` is also rewritten (ServiceAccount subjects are forced to the override namespace).
+- Potential future rewrite targets (currently not handled): webhook service namespaces (`MutatingWebhookConfiguration`, `ValidatingWebhookConfiguration`, CRD conversion webhook), and `APIService.spec.service.namespace`.
 - Fetch or parse failures stop the command (`render`, `diff`, `apply`).
 
 ## Example

--- a/nyl/book/src/reference/resources/remote-manifest.md
+++ b/nyl/book/src/reference/resources/remote-manifest.md
@@ -1,0 +1,42 @@
+# RemoteManifest
+
+`RemoteManifest` fetches YAML/JSON documents from a remote HTTPS URL and feeds
+them into Nyl's normal render pipeline.
+
+## API Version
+
+- `nyl.niklasrosenstein.github.com/v1`
+
+## Schema
+
+```yaml
+apiVersion: nyl.niklasrosenstein.github.com/v1
+kind: RemoteManifest
+metadata:
+  name: <name>
+spec:
+  url: https://example.com/path/manifests.yaml
+```
+
+### Fields
+
+- `spec.url` (required): HTTPS URL containing one or more YAML/JSON documents.
+
+## Behavior
+
+- URL must use `https://`.
+- Content is parsed as YAML multi-document stream.
+- Parsed resources are processed recursively like local resources.
+- Remote content is not rendered as a Jinja template.
+- Fetch or parse failures stop the command (`render`, `diff`, `apply`).
+
+## Example
+
+```yaml
+apiVersion: nyl.niklasrosenstein.github.com/v1
+kind: RemoteManifest
+metadata:
+  name: shared-crds
+spec:
+  url: https://example.com/platform/crds.yaml
+```

--- a/nyl/book/src/reference/resources/remote-manifest.md
+++ b/nyl/book/src/reference/resources/remote-manifest.md
@@ -31,6 +31,7 @@ spec:
 - Parsed resources are processed recursively like local resources.
 - Remote content is not rendered as a Jinja template.
 - When `spec.overrideNamespace: true`, remote manifests with `metadata.namespace` are rewritten to `RemoteManifest.metadata.namespace`.
+- Special case: for `ClusterRoleBinding` (`rbac.authorization.k8s.io/*`), `subjects[*].namespace` is also rewritten (ServiceAccount subjects are forced to the override namespace).
 - Fetch or parse failures stop the command (`render`, `diff`, `apply`).
 
 ## Example

--- a/nyl/book/src/reference/resources/remote-manifest.md
+++ b/nyl/book/src/reference/resources/remote-manifest.md
@@ -16,11 +16,13 @@ metadata:
   name: <name>
 spec:
   url: https://example.com/path/manifests.yaml
+  overrideNamespace: false
 ```
 
 ### Fields
 
 - `spec.url` (required): HTTPS URL containing one or more YAML/JSON documents.
+- `spec.overrideNamespace` (optional, default `false`): when `true`, fetched resources that already have `metadata.namespace` will have that value replaced with `RemoteManifest.metadata.namespace`.
 
 ## Behavior
 
@@ -28,6 +30,7 @@ spec:
 - Content is parsed as YAML multi-document stream.
 - Parsed resources are processed recursively like local resources.
 - Remote content is not rendered as a Jinja template.
+- When `spec.overrideNamespace: true`, remote manifests with `metadata.namespace` are rewritten to `RemoteManifest.metadata.namespace`.
 - Fetch or parse failures stop the command (`render`, `diff`, `apply`).
 
 ## Example

--- a/nyl/src/cli/commands/apply.rs
+++ b/nyl/src/cli/commands/apply.rs
@@ -7,7 +7,7 @@ use colored::Colorize;
 
 use crate::{
     cli::{
-        commands::render::{run_render_preflight, RenderOptions, RenderPreflightOptions},
+        commands::render::{run_render_preflight, ClusterClientRequirement, RenderOptions, RenderPreflightOptions},
         namespace_resolution::{adjust_duplicate_keys_for_namespace_resolution, resolve_manifest_namespaces},
     },
     kubernetes::{
@@ -54,6 +54,7 @@ pub async fn execute(args: ApplyArgs) -> Result<()> {
         kube_version: None,
         kube_api_versions: &[],
         context_override: args.context.as_deref(),
+        cluster_client_requirement: ClusterClientRequirement::Required,
         resolve_namespaces: false,
         release_namespace_hint: None,
         adjust_duplicate_keys: false,

--- a/nyl/src/cli/commands/diff.rs
+++ b/nyl/src/cli/commands/diff.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::{
     cli::{
-        commands::render::{run_render_preflight, RenderOptions, RenderPreflightOptions},
+        commands::render::{run_render_preflight, ClusterClientRequirement, RenderOptions, RenderPreflightOptions},
         namespace_resolution::{adjust_duplicate_keys_for_namespace_resolution, resolve_manifest_namespaces},
     },
     kubernetes::{
@@ -69,6 +69,7 @@ pub async fn execute(args: DiffArgs) -> Result<()> {
         kube_version: None,
         kube_api_versions: &[],
         context_override: args.context.as_deref(),
+        cluster_client_requirement: ClusterClientRequirement::Required,
         resolve_namespaces: false,
         release_namespace_hint: None,
         adjust_duplicate_keys: false,

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -707,8 +707,7 @@ fn generate_resource(
             Ok(manifests)
         }
     } else if kind == Some("RemoteManifest") && api_version == Some(API_VERSION) {
-        let remote_manifest: RemoteManifest = serde_json::from_value(resource.clone())
-            .map_err(|e| NylError::Config(format!("Failed to parse RemoteManifest: {}", e)))?;
+        let remote_manifest = RemoteManifest::from_value(resource)?;
         remote_manifest.validate()?;
         fetch_remote_manifest_documents(&remote_manifest)
     } else if is_nyl_component(resource)
@@ -865,31 +864,46 @@ fn generate_resource(
 
 fn fetch_remote_manifest_documents(remote_manifest: &RemoteManifest) -> Result<Vec<serde_json::Value>> {
     let url = remote_manifest.spec.url.trim();
+    let sanitized_url = crate::util::sanitize_url(url);
     let output = std::process::Command::new("curl")
-        .args(["--fail", "--silent", "--show-error", "--location", url])
+        .args([
+            "--fail",
+            "--silent",
+            "--show-error",
+            "--location",
+            "--proto",
+            "=https",
+            "--proto-redir",
+            "=https",
+            "--connect-timeout",
+            "5",
+            "--max-time",
+            "30",
+            url,
+        ])
         .output()
         .map_err(|e| {
             NylError::Process(format!(
                 "Failed to execute curl for RemoteManifest '{}' from {}: {}",
-                remote_manifest.metadata.name, url, e
+                remote_manifest.metadata.name, sanitized_url, e
             ))
         })?;
     if !output.status.success() {
-        return Err(NylError::Config(format!(
+        return Err(NylError::Process(format!(
             "Failed to fetch RemoteManifest '{}' from {}: curl exited with status {}: {}",
             remote_manifest.metadata.name,
-            url,
+            sanitized_url,
             output.status,
             String::from_utf8_lossy(&output.stderr)
         )));
     }
     let body = String::from_utf8(output.stdout).map_err(|e| {
-        NylError::Config(format!(
+        NylError::Process(format!(
             "RemoteManifest '{}' from {} returned non-UTF-8 content: {}",
-            remote_manifest.metadata.name, url, e
+            remote_manifest.metadata.name, sanitized_url, e
         ))
     })?;
-    let source_ctx = crate::util::SourceContext::new(PathBuf::from(format!("remote:{url}")));
+    let source_ctx = crate::util::SourceContext::new(PathBuf::from(format!("remote:{sanitized_url}")));
     let mut documents = source_ctx.parse_yaml_documents(&body)?;
     if remote_manifest.spec.override_namespace {
         override_fetched_manifest_namespaces(&mut documents, remote_manifest.metadata.namespace.as_deref());

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -18,6 +18,7 @@ use crate::{
         component_kind_to_chart_ref, extract_all_kyverno_policies, extract_application_generators, extract_nyl_release,
         is_nyl_component, is_remote_helm_chart_shortcut, is_supported_application_field_path, join_field_path_segments,
         parse_component_kind, path_matches_glob, ChartRef, HelmChart, KyvernoScope, NylComponent, NylRelease,
+        RemoteManifest,
     },
     secrets::SecretsConfig,
     template::{TemplateContext, TemplateEngine},
@@ -296,6 +297,7 @@ pub async fn render_manifests(
         let kind = r.get("kind").and_then(|k| k.as_str());
         let api_version = r.get("apiVersion").and_then(|a| a.as_str());
         (kind == Some("HelmChart") && api_version == Some(API_VERSION))
+            || (kind == Some("RemoteManifest") && api_version == Some(API_VERSION))
             || api_version == Some(API_VERSION_COMPONENTS)
             || api_version
                 .zip(kind)
@@ -545,6 +547,7 @@ fn is_renderable_resource(resource: &serde_json::Value, config: &ProjectConfig) 
     let kind = resource.get("kind").and_then(|k| k.as_str());
     let api_version = resource.get("apiVersion").and_then(|a| a.as_str());
     (kind == Some("HelmChart") && api_version == Some(API_VERSION))
+        || (kind == Some("RemoteManifest") && api_version == Some(API_VERSION))
         || is_nyl_component(resource)
         || api_version
             .zip(kind)
@@ -642,6 +645,11 @@ fn is_known_nyl_resource(resource: &serde_json::Value) -> bool {
         return true;
     }
 
+    // Check for RemoteManifest
+    if RemoteManifest::is_remote_manifest(resource) {
+        return true;
+    }
+
     // Check for ApplicationGenerator
     if let Some(api_ver) = api_version {
         if api_ver == API_VERSION_ARGOCD && kind == Some("ApplicationGenerator") {
@@ -698,6 +706,11 @@ fn generate_resource(
         } else {
             Ok(manifests)
         }
+    } else if kind == Some("RemoteManifest") && api_version == Some(API_VERSION) {
+        let remote_manifest: RemoteManifest = serde_json::from_value(resource.clone())
+            .map_err(|e| NylError::Config(format!("Failed to parse RemoteManifest: {}", e)))?;
+        remote_manifest.validate()?;
+        fetch_remote_manifest_documents(&remote_manifest)
     } else if is_nyl_component(resource)
         || api_version
             .zip(kind)
@@ -836,7 +849,7 @@ fn generate_resource(
                     "Resource with apiVersion '{}' and kind '{}' looks like a Nyl resource but is not recognized. \
                      It will be treated as a regular Kubernetes manifest. \
                      Known Nyl apiVersions: {}. \
-                     Known kinds: HelmChart, NylRelease, ApplicationGenerator, and any Component kind.",
+                     Known kinds: HelmChart, RemoteManifest, NylRelease, ApplicationGenerator, and any Component kind.",
                     api_ver,
                     kind_str,
                     api_versions_str
@@ -848,6 +861,36 @@ fn generate_resource(
         // Phase 4+: Use generator for component instantiation
         Ok(vec![resource.clone()])
     }
+}
+
+fn fetch_remote_manifest_documents(remote_manifest: &RemoteManifest) -> Result<Vec<serde_json::Value>> {
+    let url = remote_manifest.spec.url.trim();
+    let output = std::process::Command::new("curl")
+        .args(["--fail", "--silent", "--show-error", "--location", url])
+        .output()
+        .map_err(|e| {
+            NylError::Process(format!(
+                "Failed to execute curl for RemoteManifest '{}' from {}: {}",
+                remote_manifest.metadata.name, url, e
+            ))
+        })?;
+    if !output.status.success() {
+        return Err(NylError::Config(format!(
+            "Failed to fetch RemoteManifest '{}' from {}: curl exited with status {}: {}",
+            remote_manifest.metadata.name,
+            url,
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    let body = String::from_utf8(output.stdout).map_err(|e| {
+        NylError::Config(format!(
+            "RemoteManifest '{}' from {} returned non-UTF-8 content: {}",
+            remote_manifest.metadata.name, url, e
+        ))
+    })?;
+    let source_ctx = crate::util::SourceContext::new(PathBuf::from(format!("remote:{url}")));
+    source_ctx.parse_yaml_documents(&body)
 }
 
 /// Render a Helm chart
@@ -2667,6 +2710,17 @@ metadata:
     }
 
     #[test]
+    fn test_is_known_nyl_resource_remote_manifest() {
+        let resource = serde_json::json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "test"},
+            "spec": {"url": "https://example.com/manifests.yaml"}
+        });
+        assert!(is_known_nyl_resource(&resource));
+    }
+
+    #[test]
     fn test_is_known_nyl_resource_application_generator() {
         let resource = serde_json::json!({
             "apiVersion": "argocd.nyl.niklasrosenstein.github.com/v1",
@@ -2821,6 +2875,18 @@ metadata:
     }
 
     #[test]
+    fn test_is_renderable_resource_remote_manifest() {
+        let config = test_project_config();
+        let resource = serde_json::json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "test"},
+            "spec": {"url": "https://example.com/manifests.yaml"}
+        });
+        assert!(is_renderable_resource(&resource, &config));
+    }
+
+    #[test]
     fn test_is_renderable_resource_alias() {
         let mut config = test_project_config();
         config.config.project.aliases.insert(
@@ -2844,6 +2910,26 @@ metadata:
             "metadata": {"name": "test"}
         });
         assert!(!is_renderable_resource(&resource, &config));
+    }
+
+    #[test]
+    fn test_generate_resource_remote_manifest_rejects_http_url() {
+        let config = test_project_config();
+        let context = TemplateContext {
+            values: serde_json::json!({}),
+            secrets: serde_json::json!({}),
+            profile: "default".to_string(),
+        };
+        let resource = serde_json::json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "remote"},
+            "spec": {"url": "http://example.com/manifests.yaml"}
+        });
+
+        let result = generate_resource(&resource, &context, &config, "", &[], None, false);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("https://"));
     }
 
     #[test]

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -426,13 +426,7 @@ pub async fn execute(args: RenderArgs) -> Result<()> {
 }
 
 fn should_resolve_namespaces(manifests: &[serde_json::Value], offline: bool) -> bool {
-    !offline
-        && manifests.iter().any(|manifest| {
-            crate::kubernetes::extract_namespace(manifest)
-                .as_deref()
-                .map(str::trim)
-                .is_none_or(str::is_empty)
-        })
+    !offline && manifests.iter().any(manifest_requires_namespace_resolution)
 }
 
 fn should_initialize_cluster_clients(
@@ -446,6 +440,19 @@ fn should_initialize_cluster_clients(
         && (cluster_client_requirement == ClusterClientRequirement::Required
             || adjust_duplicate_keys
             || (resolve_namespaces && should_resolve_namespaces(manifests, offline)))
+}
+
+fn manifest_requires_namespace_resolution(manifest: &serde_json::Value) -> bool {
+    let has_namespace = crate::kubernetes::extract_namespace(manifest)
+        .as_deref()
+        .is_some_and(|ns| !ns.trim().is_empty());
+    if has_namespace {
+        return false;
+    }
+
+    crate::kubernetes::extract_gvk(manifest)
+        .map(|gvk| !crate::kubernetes::is_known_cluster_scoped_gvk(&gvk))
+        .unwrap_or(true)
 }
 
 /// Load YAML/JSON resources from a file path, rendering Jinja templates.
@@ -594,6 +601,7 @@ fn needs_helm_rendering(resources: &[serde_json::Value], config: &ProjectConfig)
 /// - Missing character (e.g., ".co" instead of ".com")
 /// - Extra character (e.g., "githubb" instead of "github")
 const MAX_TYPO_DISTANCE: usize = 3;
+const MAX_REMOTE_MANIFEST_BYTES: usize = 30 * 1024 * 1024;
 
 /// Check if an API version looks like it might be a Nyl resource API version
 fn is_nyl_like_api_version(api_version: &str) -> bool {
@@ -893,7 +901,7 @@ async fn fetch_remote_manifest_documents(remote_manifest: &RemoteManifest) -> Re
                 remote_manifest.metadata.name, sanitized_url, e
             ))
         })?;
-    let response = client.get(url).send().await.map_err(|e| {
+    let mut response = client.get(url).send().await.map_err(|e| {
         let detail = if e.is_timeout() {
             "request timed out"
         } else if e.is_connect() {
@@ -914,13 +922,32 @@ async fn fetch_remote_manifest_documents(remote_manifest: &RemoteManifest) -> Re
             response.status()
         )));
     }
-    let body_bytes = response.bytes().await.map_err(|e| {
+    if let Some(content_length) = response.content_length() {
+        if content_length > MAX_REMOTE_MANIFEST_BYTES as u64 {
+            return Err(NylError::Process(format!(
+                "RemoteManifest '{}' from {} exceeds size limit ({} bytes > {} bytes)",
+                remote_manifest.metadata.name, sanitized_url, content_length, MAX_REMOTE_MANIFEST_BYTES
+            )));
+        }
+    }
+
+    let mut body_bytes = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(|e| {
         NylError::Process(format!(
             "Failed to read RemoteManifest response body from {}: {}",
             sanitized_url, e
         ))
-    })?;
-    let body = String::from_utf8(body_bytes.to_vec()).map_err(|e| {
+    })? {
+        if body_bytes.len() + chunk.len() > MAX_REMOTE_MANIFEST_BYTES {
+            return Err(NylError::Process(format!(
+                "RemoteManifest '{}' from {} exceeds size limit (>{} bytes)",
+                remote_manifest.metadata.name, sanitized_url, MAX_REMOTE_MANIFEST_BYTES
+            )));
+        }
+        body_bytes.extend_from_slice(&chunk);
+    }
+
+    let body = String::from_utf8(body_bytes).map_err(|e| {
         NylError::Process(format!(
             "RemoteManifest '{}' from {} returned non-UTF-8 content: {}",
             remote_manifest.metadata.name, sanitized_url, e
@@ -3229,6 +3256,16 @@ metadata:
     }
 
     #[test]
+    fn test_should_not_resolve_namespaces_for_known_cluster_scoped_resources() {
+        let manifests = vec![serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "Namespace",
+            "metadata": {"name": "infra"}
+        })];
+        assert!(!should_resolve_namespaces(&manifests, false));
+    }
+
+    #[test]
     fn test_should_initialize_cluster_clients_offline() {
         assert!(!should_initialize_cluster_clients(
             true,
@@ -3259,6 +3296,23 @@ metadata:
         })];
 
         assert!(should_initialize_cluster_clients(
+            false,
+            ClusterClientRequirement::OnDemand,
+            true,
+            &manifests,
+            false
+        ));
+    }
+
+    #[test]
+    fn test_should_not_initialize_cluster_clients_for_cluster_scoped_resources() {
+        let manifests = vec![serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "Namespace",
+            "metadata": {"name": "infra"}
+        })];
+
+        assert!(!should_initialize_cluster_clients(
             false,
             ClusterClientRequirement::OnDemand,
             true,

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -918,6 +918,31 @@ fn override_fetched_manifest_namespaces(manifests: &mut [serde_json::Value], nam
                 serde_json::Value::String(namespace.to_string()),
             );
         }
+
+        // Special case: ClusterRoleBinding subjects can carry namespaced ServiceAccount references.
+        // Rewrite subject namespace references alongside metadata.namespace overrides.
+        let is_cluster_role_binding = obj.get("kind").and_then(|v| v.as_str()) == Some("ClusterRoleBinding")
+            && obj
+                .get("apiVersion")
+                .and_then(|v| v.as_str())
+                .is_some_and(|v| v.starts_with("rbac.authorization.k8s.io/"));
+        if is_cluster_role_binding {
+            let Some(spec_subjects) = obj.get_mut("subjects").and_then(|v| v.as_array_mut()) else {
+                continue;
+            };
+            for subject in spec_subjects {
+                let Some(subject_obj) = subject.as_object_mut() else {
+                    continue;
+                };
+                let is_service_account = subject_obj.get("kind").and_then(|v| v.as_str()) == Some("ServiceAccount");
+                if subject_obj.contains_key("namespace") || is_service_account {
+                    subject_obj.insert(
+                        "namespace".to_string(),
+                        serde_json::Value::String(namespace.to_string()),
+                    );
+                }
+            }
+        }
     }
 }
 
@@ -2993,6 +3018,27 @@ metadata:
         override_fetched_manifest_namespaces(&mut manifests, None);
 
         assert_eq!(manifests[0], original);
+    }
+
+    #[test]
+    fn test_override_fetched_manifest_namespaces_rewrites_cluster_role_binding_subject_namespaces() {
+        let mut manifests = vec![serde_json::json!({
+            "apiVersion": "rbac.authorization.k8s.io/v1",
+            "kind": "ClusterRoleBinding",
+            "metadata": {"name": "bind"},
+            "subjects": [
+                {"kind": "ServiceAccount", "name": "sa-a", "namespace": "old-a"},
+                {"kind": "ServiceAccount", "name": "sa-b"},
+                {"kind": "User", "name": "alice"}
+            ],
+            "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "ClusterRole", "name": "view"}
+        })];
+
+        override_fetched_manifest_namespaces(&mut manifests, Some("target"));
+        let subjects = manifests[0]["subjects"].as_array().unwrap();
+        assert_eq!(subjects[0]["namespace"], "target");
+        assert_eq!(subjects[1]["namespace"], "target");
+        assert!(subjects[2]["namespace"].is_null());
     }
 
     #[test]

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -90,6 +90,12 @@ enum OutputFormat {
     Json,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClusterClientRequirement {
+    OnDemand,
+    Required,
+}
+
 /// Shared render preflight arguments for render/diff/apply commands.
 pub struct RenderPreflightOptions<'a> {
     pub common: &'a RenderOptions,
@@ -97,6 +103,7 @@ pub struct RenderPreflightOptions<'a> {
     pub kube_version: Option<&'a str>,
     pub kube_api_versions: &'a [String],
     pub context_override: Option<&'a str>,
+    pub cluster_client_requirement: ClusterClientRequirement,
     pub resolve_namespaces: bool,
     pub release_namespace_hint: Option<&'a str>,
     pub adjust_duplicate_keys: bool,
@@ -133,13 +140,20 @@ pub async fn run_render_preflight(options: RenderPreflightOptions<'_>) -> Result
         &options.common.exclude_kind,
     )?;
 
-    // In non-offline mode, require cluster connectivity before proceeding.
-    let (kube_client, raw_client) = if options.offline {
-        (None, None)
-    } else {
+    let should_initialize_clients = should_initialize_cluster_clients(
+        options.offline,
+        options.cluster_client_requirement,
+        options.resolve_namespaces,
+        &manifests,
+        options.adjust_duplicate_keys,
+    );
+
+    let (kube_client, raw_client) = if should_initialize_clients {
         let config = KubeRsClient::load_kube_config_from_profile(&profile, options.context_override).await?;
         let client = Client::try_from(config)?;
         (Some(KubeRsClient::from_client(client.clone()).await?), Some(client))
+    } else {
+        (None, None)
     };
 
     let release_namespace_hint = options
@@ -294,17 +308,7 @@ pub async fn render_manifests(
     let filtered = filter_resources(resources, only_source_kind)?;
 
     // 7. Check if any resources need Helm rendering (HelmChart or Component)
-    let needs_helm_rendering = filtered.iter().any(|r| {
-        let kind = r.get("kind").and_then(|k| k.as_str());
-        let api_version = r.get("apiVersion").and_then(|a| a.as_str());
-        (kind == Some("HelmChart") && api_version == Some(API_VERSION))
-            || (kind == Some("RemoteManifest") && api_version == Some(API_VERSION))
-            || api_version == Some(API_VERSION_COMPONENTS)
-            || api_version
-                .zip(kind)
-                .and_then(|(av, k)| project_config.get_alias_target_for_kind(av, k))
-                .is_some()
-    });
+    let needs_helm_rendering = needs_helm_rendering(&filtered, &project_config);
 
     // 8. Determine kube_version and api_versions (only if needed)
     let (kube_version, api_versions) = if !needs_helm_rendering {
@@ -346,7 +350,8 @@ pub async fn render_manifests(
                 &api_versions,
                 credential_provider.clone(),
                 track_parent,
-            )?;
+            )
+            .await?;
             for manifest in manifests {
                 if is_renderable_resource(&manifest, &project_config) {
                     next_pending.push(manifest);
@@ -398,6 +403,7 @@ pub async fn execute(args: RenderArgs) -> Result<()> {
         kube_version: args.kube_version.as_deref(),
         kube_api_versions: &args.kube_api_versions,
         context_override: None,
+        cluster_client_requirement: ClusterClientRequirement::OnDemand,
         resolve_namespaces: true,
         release_namespace_hint: None,
         adjust_duplicate_keys: false,
@@ -427,6 +433,19 @@ fn should_resolve_namespaces(manifests: &[serde_json::Value], offline: bool) -> 
                 .map(str::trim)
                 .is_none_or(str::is_empty)
         })
+}
+
+fn should_initialize_cluster_clients(
+    offline: bool,
+    cluster_client_requirement: ClusterClientRequirement,
+    resolve_namespaces: bool,
+    manifests: &[serde_json::Value],
+    adjust_duplicate_keys: bool,
+) -> bool {
+    !offline
+        && (cluster_client_requirement == ClusterClientRequirement::Required
+            || adjust_duplicate_keys
+            || (resolve_namespaces && should_resolve_namespaces(manifests, offline)))
 }
 
 /// Load YAML/JSON resources from a file path, rendering Jinja templates.
@@ -556,6 +575,19 @@ fn is_renderable_resource(resource: &serde_json::Value, config: &ProjectConfig) 
             .is_some()
 }
 
+fn needs_helm_rendering(resources: &[serde_json::Value], config: &ProjectConfig) -> bool {
+    resources.iter().any(|resource| {
+        let kind = resource.get("kind").and_then(|k| k.as_str());
+        let api_version = resource.get("apiVersion").and_then(|a| a.as_str());
+        (kind == Some("HelmChart") && api_version == Some(API_VERSION))
+            || api_version == Some(API_VERSION_COMPONENTS)
+            || api_version
+                .zip(kind)
+                .and_then(|(av, k)| config.get_alias_target_for_kind(av, k))
+                .is_some()
+    })
+}
+
 /// Maximum Levenshtein distance for considering an API version as "similar" to a known Nyl domain.
 /// Distance of 3 allows for common typos like:
 /// - Single character substitution (e.g., "nikolas" instead of "niklas")
@@ -663,7 +695,7 @@ fn is_known_nyl_resource(resource: &serde_json::Value) -> bool {
 
 /// Generate manifests from a resource
 #[allow(clippy::too_many_lines)]
-fn generate_resource(
+async fn generate_resource(
     resource: &serde_json::Value,
     context: &TemplateContext,
     config: &ProjectConfig,
@@ -689,28 +721,26 @@ fn generate_resource(
             credential_provider.clone(),
         )?;
 
-        // Add parent tracking annotations if enabled
-        if track_parent {
-            Ok(manifests
-                .into_iter()
-                .map(|mut m| {
-                    add_parent_annotations(
-                        &mut m,
-                        &chart.api_version,
-                        &chart.kind,
-                        &chart.metadata.name,
-                        chart.metadata.namespace.as_deref(),
-                    );
-                    m
-                })
-                .collect())
-        } else {
-            Ok(manifests)
-        }
+        Ok(apply_parent_tracking_annotations(
+            manifests,
+            track_parent,
+            &chart.api_version,
+            &chart.kind,
+            &chart.metadata.name,
+            chart.metadata.namespace.as_deref(),
+        ))
     } else if kind == Some("RemoteManifest") && api_version == Some(API_VERSION) {
         let remote_manifest = RemoteManifest::from_value(resource)?;
         remote_manifest.validate()?;
-        fetch_remote_manifest_documents(&remote_manifest)
+        let manifests = fetch_remote_manifest_documents(&remote_manifest).await?;
+        Ok(apply_parent_tracking_annotations(
+            manifests,
+            track_parent,
+            &remote_manifest.api_version,
+            &remote_manifest.kind,
+            &remote_manifest.metadata.name,
+            remote_manifest.metadata.namespace.as_deref(),
+        ))
     } else if is_nyl_component(resource)
         || api_version
             .zip(kind)
@@ -764,24 +794,14 @@ fn generate_resource(
                 credential_provider.clone(),
             )?;
 
-            // Add parent tracking annotations if enabled
-            if track_parent {
-                Ok(manifests
-                    .into_iter()
-                    .map(|mut m| {
-                        add_parent_annotations(
-                            &mut m,
-                            &component_api_version,
-                            &component_kind,
-                            &component_name,
-                            release_namespace.as_deref(),
-                        );
-                        m
-                    })
-                    .collect())
-            } else {
-                Ok(manifests)
-            }
+            Ok(apply_parent_tracking_annotations(
+                manifests,
+                track_parent,
+                &component_api_version,
+                &component_kind,
+                &component_name,
+                release_namespace.as_deref(),
+            ))
         } else {
             // Local component path - use existing component resolution mechanism
             let chart_dir = config.resolve_component_chart_dir(&component.kind)?;
@@ -813,24 +833,14 @@ fn generate_resource(
                 credential_provider.clone(),
             )?;
 
-            // Add parent tracking annotations if enabled
-            if track_parent {
-                Ok(manifests
-                    .into_iter()
-                    .map(|mut m| {
-                        add_parent_annotations(
-                            &mut m,
-                            &component_api_version,
-                            &component_kind,
-                            &component_name,
-                            release_namespace.as_deref(),
-                        );
-                        m
-                    })
-                    .collect())
-            } else {
-                Ok(manifests)
-            }
+            Ok(apply_parent_tracking_annotations(
+                manifests,
+                track_parent,
+                &component_api_version,
+                &component_kind,
+                &component_name,
+                release_namespace.as_deref(),
+            ))
         }
     } else {
         // Check if this looks like an unknown Nyl resource
@@ -863,10 +873,10 @@ fn generate_resource(
     }
 }
 
-fn fetch_remote_manifest_documents(remote_manifest: &RemoteManifest) -> Result<Vec<serde_json::Value>> {
+async fn fetch_remote_manifest_documents(remote_manifest: &RemoteManifest) -> Result<Vec<serde_json::Value>> {
     let url = remote_manifest.spec.url.trim();
     let sanitized_url = crate::util::sanitize_url(url);
-    let client = reqwest::blocking::Client::builder()
+    let client = reqwest::Client::builder()
         .connect_timeout(Duration::from_secs(5))
         .timeout(Duration::from_secs(30))
         .redirect(reqwest::redirect::Policy::custom(|attempt| {
@@ -883,7 +893,7 @@ fn fetch_remote_manifest_documents(remote_manifest: &RemoteManifest) -> Result<V
                 remote_manifest.metadata.name, sanitized_url, e
             ))
         })?;
-    let response = client.get(url).send().map_err(|e| {
+    let response = client.get(url).send().await.map_err(|e| {
         let detail = if e.is_timeout() {
             "request timed out"
         } else if e.is_connect() {
@@ -904,7 +914,7 @@ fn fetch_remote_manifest_documents(remote_manifest: &RemoteManifest) -> Result<V
             response.status()
         )));
     }
-    let body_bytes = response.bytes().map_err(|e| {
+    let body_bytes = response.bytes().await.map_err(|e| {
         NylError::Process(format!(
             "Failed to read RemoteManifest response body from {}: {}",
             sanitized_url, e
@@ -933,10 +943,7 @@ fn override_fetched_manifest_namespaces(manifests: &mut [serde_json::Value], nam
         let Some(obj) = manifest.as_object_mut() else {
             continue;
         };
-        let metadata = obj
-            .entry("metadata")
-            .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
-        let Some(metadata_obj) = metadata.as_object_mut() else {
+        let Some(metadata_obj) = obj.get_mut("metadata").and_then(|v| v.as_object_mut()) else {
             continue;
         };
         if metadata_obj.contains_key("namespace") {
@@ -974,6 +981,33 @@ fn override_fetched_manifest_namespaces(manifests: &mut [serde_json::Value], nam
             }
         }
     }
+}
+
+fn apply_parent_tracking_annotations(
+    manifests: Vec<serde_json::Value>,
+    track_parent: bool,
+    parent_api_version: &str,
+    parent_kind: &str,
+    parent_name: &str,
+    parent_namespace: Option<&str>,
+) -> Vec<serde_json::Value> {
+    if !track_parent {
+        return manifests;
+    }
+
+    manifests
+        .into_iter()
+        .map(|mut manifest| {
+            add_parent_annotations(
+                &mut manifest,
+                parent_api_version,
+                parent_kind,
+                parent_name,
+                parent_namespace,
+            );
+            manifest
+        })
+        .collect()
 }
 
 /// Render a Helm chart
@@ -2925,6 +2959,66 @@ metadata:
     }
 
     #[test]
+    fn test_apply_parent_tracking_annotations_remote_manifest() {
+        use crate::constants::{ANNOTATION_PARENT_KIND, ANNOTATION_PARENT_NAME, ANNOTATION_PARENT_NAMESPACE};
+
+        let manifests = vec![serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": "cm"}
+        })];
+
+        let manifests = apply_parent_tracking_annotations(
+            manifests,
+            true,
+            "nyl.niklasrosenstein.github.com/v1",
+            "RemoteManifest",
+            "remote-a",
+            Some("apps"),
+        );
+
+        let annotations = manifests[0]["metadata"]["annotations"].as_object().unwrap();
+        assert_eq!(
+            annotations.get(ANNOTATION_PARENT_KIND).unwrap().as_str().unwrap(),
+            "RemoteManifest"
+        );
+        assert_eq!(
+            annotations.get(ANNOTATION_PARENT_NAME).unwrap().as_str().unwrap(),
+            "remote-a"
+        );
+        assert_eq!(
+            annotations.get(ANNOTATION_PARENT_NAMESPACE).unwrap().as_str().unwrap(),
+            "apps"
+        );
+    }
+
+    #[test]
+    fn test_needs_helm_rendering_ignores_remote_manifest() {
+        let config = test_project_config();
+        let resources = vec![serde_json::json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "remote"},
+            "spec": {"url": "https://example.com/manifest.yaml"}
+        })];
+
+        assert!(!needs_helm_rendering(&resources, &config));
+    }
+
+    #[test]
+    fn test_needs_helm_rendering_detects_helm_chart() {
+        let config = test_project_config();
+        let resources = vec![serde_json::json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "HelmChart",
+            "metadata": {"name": "chart"},
+            "spec": {"chart": {"name": "nginx"}}
+        })];
+
+        assert!(needs_helm_rendering(&resources, &config));
+    }
+
+    #[test]
     fn test_is_renderable_resource_helm_chart() {
         let config = test_project_config();
         let resource = serde_json::json!({
@@ -2995,8 +3089,8 @@ metadata:
         assert!(!is_renderable_resource(&resource, &config));
     }
 
-    #[test]
-    fn test_generate_resource_remote_manifest_rejects_http_url() {
+    #[tokio::test]
+    async fn test_generate_resource_remote_manifest_rejects_http_url() {
         let config = test_project_config();
         let context = TemplateContext {
             values: serde_json::json!({}),
@@ -3010,7 +3104,7 @@ metadata:
             "spec": {"url": "http://example.com/manifests.yaml"}
         });
 
-        let result = generate_resource(&resource, &context, &config, "", &[], None, false);
+        let result = generate_resource(&resource, &context, &config, "", &[], None, false).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("https://"));
     }
@@ -3034,6 +3128,18 @@ metadata:
 
         assert_eq!(manifests[0]["metadata"]["namespace"], "target");
         assert!(manifests[1]["metadata"]["namespace"].is_null());
+    }
+
+    #[test]
+    fn test_override_fetched_manifest_namespaces_does_not_add_metadata() {
+        let mut manifests = vec![serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "ConfigMap"
+        })];
+
+        override_fetched_manifest_namespaces(&mut manifests, Some("target"));
+
+        assert!(manifests[0].get("metadata").is_none());
     }
 
     #[test]
@@ -3120,5 +3226,72 @@ metadata:
             "metadata": {"name": "sa", "namespace": "default"}
         })];
         assert!(!should_resolve_namespaces(&manifests, false));
+    }
+
+    #[test]
+    fn test_should_initialize_cluster_clients_offline() {
+        assert!(!should_initialize_cluster_clients(
+            true,
+            ClusterClientRequirement::Required,
+            true,
+            &[],
+            true
+        ));
+    }
+
+    #[test]
+    fn test_should_initialize_cluster_clients_required() {
+        assert!(should_initialize_cluster_clients(
+            false,
+            ClusterClientRequirement::Required,
+            false,
+            &[],
+            false
+        ));
+    }
+
+    #[test]
+    fn test_should_initialize_cluster_clients_for_namespace_resolution() {
+        let manifests = vec![serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "ServiceAccount",
+            "metadata": {"name": "sa"}
+        })];
+
+        assert!(should_initialize_cluster_clients(
+            false,
+            ClusterClientRequirement::OnDemand,
+            true,
+            &manifests,
+            false
+        ));
+    }
+
+    #[test]
+    fn test_should_not_initialize_cluster_clients_when_not_needed() {
+        let manifests = vec![serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "ServiceAccount",
+            "metadata": {"name": "sa", "namespace": "default"}
+        })];
+
+        assert!(!should_initialize_cluster_clients(
+            false,
+            ClusterClientRequirement::OnDemand,
+            true,
+            &manifests,
+            false
+        ));
+    }
+
+    #[test]
+    fn test_should_initialize_cluster_clients_for_duplicate_adjustment() {
+        assert!(should_initialize_cluster_clients(
+            false,
+            ClusterClientRequirement::OnDemand,
+            false,
+            &[],
+            true
+        ));
     }
 }

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -890,7 +890,35 @@ fn fetch_remote_manifest_documents(remote_manifest: &RemoteManifest) -> Result<V
         ))
     })?;
     let source_ctx = crate::util::SourceContext::new(PathBuf::from(format!("remote:{url}")));
-    source_ctx.parse_yaml_documents(&body)
+    let mut documents = source_ctx.parse_yaml_documents(&body)?;
+    if remote_manifest.spec.override_namespace {
+        override_fetched_manifest_namespaces(&mut documents, remote_manifest.metadata.namespace.as_deref());
+    }
+    Ok(documents)
+}
+
+fn override_fetched_manifest_namespaces(manifests: &mut [serde_json::Value], namespace: Option<&str>) {
+    let Some(namespace) = namespace else {
+        return;
+    };
+
+    for manifest in manifests {
+        let Some(obj) = manifest.as_object_mut() else {
+            continue;
+        };
+        let metadata = obj
+            .entry("metadata")
+            .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+        let Some(metadata_obj) = metadata.as_object_mut() else {
+            continue;
+        };
+        if metadata_obj.contains_key("namespace") {
+            metadata_obj.insert(
+                "namespace".to_string(),
+                serde_json::Value::String(namespace.to_string()),
+            );
+        }
+    }
 }
 
 /// Render a Helm chart
@@ -2930,6 +2958,41 @@ metadata:
         let result = generate_resource(&resource, &context, &config, "", &[], None, false);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("https://"));
+    }
+
+    #[test]
+    fn test_override_fetched_manifest_namespaces_overwrites_existing_namespace() {
+        let mut manifests = vec![
+            serde_json::json!({
+                "apiVersion": "v1",
+                "kind": "ConfigMap",
+                "metadata": {"name": "cm", "namespace": "old"}
+            }),
+            serde_json::json!({
+                "apiVersion": "apps/v1",
+                "kind": "Deployment",
+                "metadata": {"name": "dep"}
+            }),
+        ];
+
+        override_fetched_manifest_namespaces(&mut manifests, Some("target"));
+
+        assert_eq!(manifests[0]["metadata"]["namespace"], "target");
+        assert!(manifests[1]["metadata"]["namespace"].is_null());
+    }
+
+    #[test]
+    fn test_override_fetched_manifest_namespaces_no_namespace_hint_is_noop() {
+        let original = serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": "cm", "namespace": "old"}
+        });
+        let mut manifests = vec![original.clone()];
+
+        override_fetched_manifest_namespaces(&mut manifests, None);
+
+        assert_eq!(manifests[0], original);
     }
 
     #[test]

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -919,14 +919,17 @@ fn override_fetched_manifest_namespaces(manifests: &mut [serde_json::Value], nam
             );
         }
 
-        // Special case: ClusterRoleBinding subjects can carry namespaced ServiceAccount references.
+        // Special case: RoleBinding/ClusterRoleBinding subjects can carry namespaced ServiceAccount references.
         // Rewrite subject namespace references alongside metadata.namespace overrides.
-        let is_cluster_role_binding = obj.get("kind").and_then(|v| v.as_str()) == Some("ClusterRoleBinding")
-            && obj
-                .get("apiVersion")
-                .and_then(|v| v.as_str())
-                .is_some_and(|v| v.starts_with("rbac.authorization.k8s.io/"));
-        if is_cluster_role_binding {
+        let is_rbac_binding_kind = obj
+            .get("kind")
+            .and_then(|v| v.as_str())
+            .is_some_and(|k| k == "RoleBinding" || k == "ClusterRoleBinding");
+        let is_rbac_api_group = obj
+            .get("apiVersion")
+            .and_then(|v| v.as_str())
+            .is_some_and(|v| v.starts_with("rbac.authorization.k8s.io/"));
+        if is_rbac_binding_kind && is_rbac_api_group {
             let Some(spec_subjects) = obj.get_mut("subjects").and_then(|v| v.as_array_mut()) else {
                 continue;
             };
@@ -3032,6 +3035,27 @@ metadata:
                 {"kind": "User", "name": "alice"}
             ],
             "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "ClusterRole", "name": "view"}
+        })];
+
+        override_fetched_manifest_namespaces(&mut manifests, Some("target"));
+        let subjects = manifests[0]["subjects"].as_array().unwrap();
+        assert_eq!(subjects[0]["namespace"], "target");
+        assert_eq!(subjects[1]["namespace"], "target");
+        assert!(subjects[2]["namespace"].is_null());
+    }
+
+    #[test]
+    fn test_override_fetched_manifest_namespaces_rewrites_role_binding_subject_namespaces() {
+        let mut manifests = vec![serde_json::json!({
+            "apiVersion": "rbac.authorization.k8s.io/v1",
+            "kind": "RoleBinding",
+            "metadata": {"name": "bind", "namespace": "source"},
+            "subjects": [
+                {"kind": "ServiceAccount", "name": "sa-a", "namespace": "old-a"},
+                {"kind": "ServiceAccount", "name": "sa-b"},
+                {"kind": "User", "name": "alice"}
+            ],
+            "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "Role", "name": "view"}
         })];
 
         override_fetched_manifest_namespaces(&mut manifests, Some("target"));

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::{
     cli::namespace_resolution::{adjust_duplicate_keys_for_namespace_resolution, resolve_manifest_namespaces},
@@ -865,39 +866,51 @@ fn generate_resource(
 fn fetch_remote_manifest_documents(remote_manifest: &RemoteManifest) -> Result<Vec<serde_json::Value>> {
     let url = remote_manifest.spec.url.trim();
     let sanitized_url = crate::util::sanitize_url(url);
-    let output = std::process::Command::new("curl")
-        .args([
-            "--fail",
-            "--silent",
-            "--show-error",
-            "--location",
-            "--proto",
-            "=https",
-            "--proto-redir",
-            "=https",
-            "--connect-timeout",
-            "5",
-            "--max-time",
-            "30",
-            url,
-        ])
-        .output()
+    let client = reqwest::blocking::Client::builder()
+        .connect_timeout(Duration::from_secs(5))
+        .timeout(Duration::from_secs(30))
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            if attempt.url().scheme() == "https" {
+                attempt.follow()
+            } else {
+                attempt.stop()
+            }
+        }))
+        .build()
         .map_err(|e| {
             NylError::Process(format!(
-                "Failed to execute curl for RemoteManifest '{}' from {}: {}",
+                "Failed to initialize HTTPS client for RemoteManifest '{}' from {}: {}",
                 remote_manifest.metadata.name, sanitized_url, e
             ))
         })?;
-    if !output.status.success() {
+    let response = client.get(url).send().map_err(|e| {
+        let detail = if e.is_timeout() {
+            "request timed out"
+        } else if e.is_connect() {
+            "connection failed"
+        } else {
+            "request failed"
+        };
+        NylError::Process(format!(
+            "Failed to fetch RemoteManifest '{}' from {}: {}",
+            remote_manifest.metadata.name, sanitized_url, detail
+        ))
+    })?;
+    if !response.status().is_success() {
         return Err(NylError::Process(format!(
-            "Failed to fetch RemoteManifest '{}' from {}: curl exited with status {}: {}",
+            "Failed to fetch RemoteManifest '{}' from {}: HTTP {}",
             remote_manifest.metadata.name,
             sanitized_url,
-            output.status,
-            String::from_utf8_lossy(&output.stderr)
+            response.status()
         )));
     }
-    let body = String::from_utf8(output.stdout).map_err(|e| {
+    let body_bytes = response.bytes().map_err(|e| {
+        NylError::Process(format!(
+            "Failed to read RemoteManifest response body from {}: {}",
+            sanitized_url, e
+        ))
+    })?;
+    let body = String::from_utf8(body_bytes.to_vec()).map_err(|e| {
         NylError::Process(format!(
             "RemoteManifest '{}' from {} returned non-UTF-8 content: {}",
             remote_manifest.metadata.name, sanitized_url, e

--- a/nyl/src/kubernetes/client.rs
+++ b/nyl/src/kubernetes/client.rs
@@ -566,7 +566,7 @@ fn is_known_cluster_scoped_kind(kind: &str) -> bool {
     )
 }
 
-fn is_known_cluster_scoped_gvk(gvk: &GroupVersionKind) -> bool {
+pub(crate) fn is_known_cluster_scoped_gvk(gvk: &GroupVersionKind) -> bool {
     match gvk.group.as_str() {
         "" => is_known_cluster_scoped_kind(&gvk.kind),
         "rbac.authorization.k8s.io" => matches!(gvk.kind.as_str(), "ClusterRole" | "ClusterRoleBinding"),

--- a/nyl/src/kubernetes/mod.rs
+++ b/nyl/src/kubernetes/mod.rs
@@ -10,6 +10,7 @@ mod ordering;
 mod resource;
 mod state;
 
+pub(crate) use client::is_known_cluster_scoped_gvk;
 pub use client::{KubeClient, KubeRsClient, MockKubeClient};
 pub use diff::DiffEngine;
 pub use ordering::ResourceOrdering;

--- a/nyl/src/main.rs
+++ b/nyl/src/main.rs
@@ -1,11 +1,14 @@
 use clap::Parser;
 use nyl::cli::Cli;
 use nyl::NylError;
+use rustls::crypto::aws_lc_rs;
 use std::path::{Path, PathBuf};
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
 async fn main() {
+    install_rustls_crypto_provider();
+
     // Parse CLI first to get verbose flag and color choice
     let cli = Cli::parse();
     let render_input_path = cli.render_input_path().map(std::string::ToString::to_string);
@@ -35,6 +38,11 @@ async fn main() {
         }
         std::process::exit(1);
     }
+}
+
+fn install_rustls_crypto_provider() {
+    // reqwest's rustls backend requires a process-global provider in rustls 0.23.
+    let _ = aws_lc_rs::default_provider().install_default();
 }
 
 fn emit_argocd_file_not_found_diagnostics(error: &NylError, render_input_path: &str) {

--- a/nyl/src/resources/mod.rs
+++ b/nyl/src/resources/mod.rs
@@ -8,6 +8,7 @@ mod helmchart;
 mod kyverno;
 mod nyl_release;
 mod path_glob;
+mod remote_manifest;
 
 pub use application_generator::{
     extract_application_generators, ApplicationDestination, ApplicationGenerator, ApplicationGeneratorMetadata,
@@ -25,3 +26,4 @@ pub use kyverno::{
 };
 pub use nyl_release::{extract_nyl_release, NylRelease, NylReleaseArgoCdSpec, NylReleaseMetadata, NylReleaseSpec};
 pub use path_glob::{join_segments as join_field_path_segments, path_matches_glob, validate_path_glob_pattern};
+pub use remote_manifest::RemoteManifest;

--- a/nyl/src/resources/mod.rs
+++ b/nyl/src/resources/mod.rs
@@ -26,4 +26,4 @@ pub use kyverno::{
 };
 pub use nyl_release::{extract_nyl_release, NylRelease, NylReleaseArgoCdSpec, NylReleaseMetadata, NylReleaseSpec};
 pub use path_glob::{join_segments as join_field_path_segments, path_matches_glob, validate_path_glob_pattern};
-pub use remote_manifest::RemoteManifest;
+pub use remote_manifest::{RemoteManifest, RemoteManifestSpec};

--- a/nyl/src/resources/remote_manifest.rs
+++ b/nyl/src/resources/remote_manifest.rs
@@ -1,0 +1,128 @@
+/// RemoteManifest resource definition
+///
+/// A RemoteManifest fetches YAML/JSON documents from an HTTPS URL and injects
+/// them into the normal render pipeline.
+use serde::{Deserialize, Serialize};
+
+use crate::constants::API_VERSION;
+use crate::resources::ObjectMetadata;
+use crate::{NylError, Result};
+
+/// RemoteManifest specification
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RemoteManifestSpec {
+    /// HTTPS URL to fetch manifest documents from
+    pub url: String,
+}
+
+/// RemoteManifest resource
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RemoteManifest {
+    /// API version (must be core Nyl API version)
+    #[serde(rename = "apiVersion")]
+    pub api_version: String,
+    /// Resource kind (always "RemoteManifest")
+    pub kind: String,
+    /// Kubernetes metadata
+    pub metadata: ObjectMetadata,
+    /// Remote manifest source configuration
+    pub spec: RemoteManifestSpec,
+}
+
+impl RemoteManifest {
+    /// Check if a manifest is a RemoteManifest resource
+    pub fn is_remote_manifest(manifest: &serde_json::Value) -> bool {
+        manifest.get("apiVersion").and_then(|v| v.as_str()) == Some(API_VERSION)
+            && manifest.get("kind").and_then(|v| v.as_str()) == Some("RemoteManifest")
+    }
+
+    /// Parse a RemoteManifest from a JSON value
+    pub fn from_value(value: &serde_json::Value) -> Result<Self> {
+        serde_json::from_value(value.clone())
+            .map_err(|e| NylError::Config(format!("Invalid RemoteManifest resource: {}", e)))
+    }
+
+    /// Validate the RemoteManifest configuration
+    pub fn validate(&self) -> Result<()> {
+        let url = self.spec.url.trim();
+        if url.is_empty() {
+            return Err(NylError::Config(
+                "RemoteManifest spec.url must not be empty".to_string(),
+            ));
+        }
+        if !url.starts_with("https://") {
+            return Err(NylError::Config(format!(
+                "RemoteManifest spec.url must use https:// scheme, got '{}'",
+                self.spec.url
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_is_remote_manifest_true() {
+        let manifest = json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "remote"},
+            "spec": {"url": "https://example.com/manifests.yaml"}
+        });
+        assert!(RemoteManifest::is_remote_manifest(&manifest));
+    }
+
+    #[test]
+    fn test_is_remote_manifest_false() {
+        let manifest = json!({
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": "cm"}
+        });
+        assert!(!RemoteManifest::is_remote_manifest(&manifest));
+    }
+
+    #[test]
+    fn test_remote_manifest_validate_rejects_empty_url() {
+        let manifest = json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "remote"},
+            "spec": {"url": "   "}
+        });
+        let remote = RemoteManifest::from_value(&manifest).unwrap();
+        let err = remote.validate().unwrap_err();
+        assert!(err.to_string().contains("must not be empty"));
+    }
+
+    #[test]
+    fn test_remote_manifest_validate_rejects_non_https_url() {
+        let manifest = json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "remote"},
+            "spec": {"url": "http://example.com/manifests.yaml"}
+        });
+        let remote = RemoteManifest::from_value(&manifest).unwrap();
+        let err = remote.validate().unwrap_err();
+        assert!(err.to_string().contains("https://"));
+    }
+
+    #[test]
+    fn test_remote_manifest_from_value_rejects_unknown_fields() {
+        let manifest = json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "remote"},
+            "spec": {"url": "https://example.com/manifests.yaml", "unknownField": true}
+        });
+        let err = RemoteManifest::from_value(&manifest).unwrap_err();
+        assert!(err.to_string().contains("unknown field"));
+    }
+}

--- a/nyl/src/resources/remote_manifest.rs
+++ b/nyl/src/resources/remote_manifest.rs
@@ -14,6 +14,9 @@ use crate::{NylError, Result};
 pub struct RemoteManifestSpec {
     /// HTTPS URL to fetch manifest documents from
     pub url: String,
+    /// Overwrite fetched manifest metadata.namespace with RemoteManifest metadata.namespace
+    #[serde(default, rename = "overrideNamespace", skip_serializing_if = "std::ops::Not::not")]
+    pub override_namespace: bool,
 }
 
 /// RemoteManifest resource
@@ -112,6 +115,33 @@ mod tests {
         let remote = RemoteManifest::from_value(&manifest).unwrap();
         let err = remote.validate().unwrap_err();
         assert!(err.to_string().contains("https://"));
+    }
+
+    #[test]
+    fn test_remote_manifest_override_namespace_defaults_to_false() {
+        let manifest = json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "remote"},
+            "spec": {"url": "https://example.com/manifests.yaml"}
+        });
+        let remote = RemoteManifest::from_value(&manifest).unwrap();
+        assert!(!remote.spec.override_namespace);
+    }
+
+    #[test]
+    fn test_remote_manifest_override_namespace_true() {
+        let manifest = json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "remote"},
+            "spec": {
+                "url": "https://example.com/manifests.yaml",
+                "overrideNamespace": true
+            }
+        });
+        let remote = RemoteManifest::from_value(&manifest).unwrap();
+        assert!(remote.spec.override_namespace);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add new core `RemoteManifest` resource (`nyl.niklasrosenstein.github.com/v1`)
- integrate `RemoteManifest` into render expansion pipeline with recursive processing
- enforce HTTPS-only URL validation and fail-fast fetch/parse behavior
- update resource reference docs and rendering pipeline docs

## Testing
- `cd nyl && cargo fmt`
- `cd nyl && cargo test remote_manifest -- --nocapture`
