### PR TITLE
fix: prevent YAML 1.1 boolean coercion of ambiguous strings

### DIFF
--- a/nyl/src/helm/template.rs
+++ b/nyl/src/helm/template.rs
@@ -191,8 +191,8 @@ fn write_values_file(values: &serde_json::Value) -> Result<tempfile::NamedTempFi
     let mut temp_file =
         tempfile::NamedTempFile::new().map_err(|e| NylError::Config(format!("Failed to create temp file: {}", e)))?;
 
-    let yaml =
-        crate::yaml::serialize_yaml_document(values).map_err(|e| NylError::Config(format!("Failed to serialize values: {}", e)))?;
+    let yaml = crate::yaml::serialize_yaml_document(values)
+        .map_err(|e| NylError::Config(format!("Failed to serialize values: {}", e)))?;
 
     temp_file
         .write_all(yaml.as_bytes())

--- a/nyl/src/helm/template.rs
+++ b/nyl/src/helm/template.rs
@@ -192,7 +192,7 @@ fn write_values_file(values: &serde_json::Value) -> Result<tempfile::NamedTempFi
         tempfile::NamedTempFile::new().map_err(|e| NylError::Config(format!("Failed to create temp file: {}", e)))?;
 
     let yaml =
-        serde_norway::to_string(values).map_err(|e| NylError::Config(format!("Failed to serialize values: {}", e)))?;
+        crate::yaml::serialize_yaml_document(values).map_err(|e| NylError::Config(format!("Failed to serialize values: {}", e)))?;
 
     temp_file
         .write_all(yaml.as_bytes())

--- a/nyl/src/postprocess/kyverno.rs
+++ b/nyl/src/postprocess/kyverno.rs
@@ -64,7 +64,7 @@ fn apply_kyverno_policies_internal(
     let mut policy_files = Vec::new();
     for (idx, policy) in policies.iter().enumerate() {
         let policy_file = policies_dir.join(format!("policy-{}.yaml", idx));
-        let policy_yaml = serde_norway::to_string(policy).map_err(NylError::Yaml)?;
+        let policy_yaml = crate::yaml::serialize_yaml_document(policy).map_err(NylError::YamlEmit)?;
         fs::write(&policy_file, policy_yaml)
             .map_err(|e| NylError::Config(format!("Failed to write policy file: {}", e)))?;
         policy_files.push(policy_file);
@@ -104,7 +104,7 @@ fn write_manifests_to_file(path: &Path, manifests: &[&serde_json::Value]) -> Res
         if i > 0 {
             writeln!(file, "---").map_err(|e| NylError::Config(format!("Failed to write separator to file: {}", e)))?;
         }
-        let yaml = serde_norway::to_string(manifest).map_err(NylError::Yaml)?;
+        let yaml = crate::yaml::serialize_yaml_document(manifest).map_err(NylError::YamlEmit)?;
         write!(file, "{}", yaml).map_err(|e| NylError::Config(format!("Failed to write manifest to file: {}", e)))?;
     }
 
@@ -182,7 +182,7 @@ fn read_kyverno_output(output_dir: &Path, original_manifests: &[serde_json::Valu
             if trimmed.is_empty() {
                 continue;
             }
-            match serde_norway::from_str::<serde_json::Value>(trimmed) {
+            match crate::yaml::parse_yaml_value_k8s_compatible(trimmed) {
                 Ok(value) if !value.is_null() => manifests.push(value),
                 Ok(_) => {}
                 Err(e) => {

--- a/nyl/src/yaml/mod.rs
+++ b/nyl/src/yaml/mod.rs
@@ -308,4 +308,18 @@ items:
         assert!(!yaml.contains("value: ''"));
         assert!(!yaml.contains("value: \"\""));
     }
+
+    #[test]
+    fn test_roundtrip_ambiguous_strings_preserved() {
+        let original = serde_json::json!({
+            "command": ["yes", "no", "on", "off", "true", "false"],
+            "enabled": "yes",
+            "label": "safe-string",
+        });
+
+        let yaml = serialize_yaml_document(&original).unwrap();
+        let docs = parse_yaml_documents_k8s_compatible(&yaml).unwrap();
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0], original);
+    }
 }


### PR DESCRIPTION
## Summary

- Use `serialize_yaml_document` (serde_yml) instead of `serde_norway::to_string` for intermediate YAML written to disk in Helm values files and Kyverno policy/manifest serialization, ensuring strings like `"yes"`, `"no"`, `"on"`, `"off"` are quoted
- Switch Kyverno output re-parsing from `serde_norway::from_str` to `parse_yaml_value_k8s_compatible` for consistency with the rest of the pipeline
- Add round-trip test verifying ambiguous strings survive `serialize_yaml_document` + `parse_yaml_documents_k8s_compatible`

## Context

When `nyl render` processes manifests through Helm or Kyverno, string values like `"yes"` were serialized as unquoted plain scalars by `serde_norway::to_string` (YAML 1.2). Go-based YAML 1.1 parsers in Helm and Kyverno then interpret these as booleans (`yes` → `true`), corrupting manifest values like `command: ["yes"]`.

The final output serializer (`serde_yml::to_string`) already handled this correctly by quoting ambiguous strings. This fix applies the same serializer to all intermediate YAML written to disk.

## Test plan

- [x] `cargo test -p nyl` — all existing tests pass + new round-trip test passes
- [x] `cargo build -p nyl` — no compilation errors
- [ ] Manual: render a manifest containing `command: ["yes"]` and verify the output preserves it as a string

🤖 Generated with [Claude Code](https://claude.com/claude-code)