### PR TITLE
fix: support append overrides in ArgoCD applicationOverride

### DIFF
--- a/nyl/book/src/argocd/application-generator.md
+++ b/nyl/book/src/argocd/application-generator.md
@@ -145,6 +145,8 @@ annotations:
 Controls project-level `NylRelease.spec.argocd.applicationOverride` customization of generated Applications.
 
 - `NylRelease` overrides are always evaluated against effective `allowedPaths`/`deniedPaths`.
+- `+<field>` append overrides are matched against the canonical field path without the `+` prefix.
+  - Example: `spec.syncPolicy.+syncOptions` is checked as `spec.syncPolicy.syncOptions`.
 - If `releaseCustomization` is omitted, defaults are used.
 - `allowedPaths` and `deniedPaths` use dotted field globs:
   - `*` matches one segment (does not cross dots)
@@ -156,7 +158,7 @@ Controls project-level `NylRelease.spec.argocd.applicationOverride` customizatio
   - `spec.syncPolicy.**`
 - If `allowedPaths` is an empty list, no fields are allowed.
 
-Ignored fields (unsupported/disallowed) are not applied and are reported in generated `Application.spec.info`.
+Ignored fields (unsupported/disallowed/invalid) are not applied and are reported in generated `Application.spec.info`.
 
 ## File Filtering
 
@@ -243,6 +245,61 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - PruneLast=true
+```
+
+### With Release-Level `+syncOptions`
+
+Generator defaults can be extended from a discovered `NylRelease` instead of replaced.
+
+ApplicationGenerator:
+
+```yaml
+apiVersion: argocd.nyl.niklasrosenstein.github.com/v1
+kind: ApplicationGenerator
+metadata:
+  name: home-lab
+  namespace: argocd
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  source:
+    repoURL: git@gitlab.com:NiklasRosenstein/config.git
+    targetRevision: HEAD
+    path: kasoku.netbird.selfhosted/gitops/home-lab
+  project: home-lab
+  syncPolicy:
+    syncOptions:
+      - ServerSideApply=true
+      - ApplyOutOfSyncOnly=true
+```
+
+NylRelease:
+
+```yaml
+apiVersion: nyl.niklasrosenstein.github.com/v1
+kind: NylRelease
+metadata:
+  name: service-proxies
+  namespace: home-proxy
+spec:
+  argocd:
+    applicationOverride:
+      spec:
+        syncPolicy:
+          +syncOptions:
+            - RespectIgnoreDifferences=false
+```
+
+Generated Application excerpt:
+
+```yaml
+spec:
+  syncPolicy:
+    syncOptions:
+      - ServerSideApply=true
+      - ApplyOutOfSyncOnly=true
+      - RespectIgnoreDifferences=false
 ```
 
 ### Custom File Filtering

--- a/nyl/book/src/reference/resources/nyl-release.md
+++ b/nyl/book/src/reference/resources/nyl-release.md
@@ -35,7 +35,11 @@ spec: {}              # Reserved for future use
 - **Description**: Partial ArgoCD `Application` override for use with `ApplicationGenerator` release customization policy
 - **Behavior**:
   - Override fields are applied only if allowed by `ApplicationGenerator.spec.releaseCustomization`
+  - Plain keys replace the generated `Application` value at that field path
+  - Keys prefixed with `+` append to list-valued `Application` fields instead of replacing them
+  - `+<field>` uses the canonical field path without `+` for allow/deny checks
   - Unsupported or disallowed fields are ignored
+  - Invalid append operations (for example using `+` on a non-list field or with a non-list value) are ignored
   - Ignored fields are reported as a warning in generated `Application.spec.info`
 
 ## Behavior
@@ -167,6 +171,45 @@ spec:
           value: myapp          # From NylRelease.metadata.name
         - name: NYL_RELEASE_NAMESPACE
           value: production     # From NylRelease.metadata.namespace
+```
+
+### Appending Sync Options
+
+`applicationOverride` can append to list-valued Application fields by prefixing the field name with `+`.
+
+```yaml
+apiVersion: nyl.niklasrosenstein.github.com/v1
+kind: NylRelease
+metadata:
+  name: service-proxies
+  namespace: home-proxy
+spec:
+  argocd:
+    applicationOverride:
+      spec:
+        syncPolicy:
+          +syncOptions:
+            - RespectIgnoreDifferences=false
+```
+
+When combined with an `ApplicationGenerator` default such as:
+
+```yaml
+syncPolicy:
+  syncOptions:
+    - ServerSideApply=true
+    - ApplyOutOfSyncOnly=true
+```
+
+the generated ArgoCD `Application` contains all three entries in order:
+
+```yaml
+spec:
+  syncPolicy:
+    syncOptions:
+      - ServerSideApply=true
+      - ApplyOutOfSyncOnly=true
+      - RespectIgnoreDifferences=false
 ```
 
 ### ApplicationGenerator Discovery

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -17,9 +17,9 @@ use crate::{
     profiles::{deep_merge_value, Profile},
     resources::{
         component_kind_to_chart_ref, extract_all_kyverno_policies, extract_application_generators, extract_nyl_release,
-        is_nyl_component, is_remote_helm_chart_shortcut, is_supported_application_field_path, join_field_path_segments,
-        parse_component_kind, path_matches_glob, ChartRef, HelmChart, KyvernoScope, NylComponent, NylRelease,
-        RemoteManifest,
+        is_nyl_component, is_remote_helm_chart_shortcut, is_supported_application_array_field_path,
+        is_supported_application_field_path, join_field_path_segments, parse_component_kind, path_matches_glob,
+        ChartRef, HelmChart, KyvernoScope, NylComponent, NylRelease, RemoteManifest,
     },
     secrets::SecretsConfig,
     template::{TemplateContext, TemplateEngine},
@@ -1512,6 +1512,7 @@ const IMMUTABLE_APPLICATION_PATH_PATTERNS: &[&str] = &[
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum IgnoredOverrideReason {
     Disallowed,
+    Invalid,
     Unsupported,
 }
 
@@ -1519,6 +1520,7 @@ impl IgnoredOverrideReason {
     fn as_str(&self) -> &'static str {
         match self {
             Self::Disallowed => "disallowed",
+            Self::Invalid => "invalid",
             Self::Unsupported => "unsupported",
         }
     }
@@ -1531,10 +1533,18 @@ struct IgnoredOverride {
 }
 
 #[derive(Debug, Clone)]
+enum OverrideLeafOperation {
+    Append,
+    Replace,
+}
+
+#[derive(Debug, Clone)]
 struct OverrideLeaf {
     segments: Vec<String>,
     path: String,
+    original_path: String,
     value: serde_json::Value,
+    operation: OverrideLeafOperation,
 }
 
 /// Create ArgoCD Application from generator config
@@ -1630,10 +1640,13 @@ fn apply_release_customization_overrides(
     };
 
     let mut override_leaves = Vec::new();
-    let mut prefix = Vec::new();
+    let mut original_prefix = Vec::new();
+    let mut canonical_prefix = Vec::new();
     flatten_override_leaves(
         &serde_json::Value::Object(application_override),
-        &mut prefix,
+        &mut original_prefix,
+        &mut canonical_prefix,
+        OverrideLeafOperation::Replace,
         &mut override_leaves,
     );
 
@@ -1641,7 +1654,8 @@ fn apply_release_customization_overrides(
         return Ok(());
     }
 
-    let mut applied = Vec::new();
+    let mut replace_leaves = Vec::new();
+    let mut append_leaves = Vec::new();
     let mut ignored = Vec::new();
 
     let customization =
@@ -1659,7 +1673,7 @@ fn apply_release_customization_overrides(
     for leaf in override_leaves {
         if !is_supported_application_field_path(&leaf.path) {
             ignored.push(IgnoredOverride {
-                path: leaf.path,
+                path: leaf.original_path,
                 reason: IgnoredOverrideReason::Unsupported,
             });
             continue;
@@ -1667,7 +1681,7 @@ fn apply_release_customization_overrides(
 
         if path_matches_any(&leaf.path, IMMUTABLE_APPLICATION_PATH_PATTERNS)? {
             ignored.push(IgnoredOverride {
-                path: leaf.path,
+                path: leaf.original_path,
                 reason: IgnoredOverrideReason::Disallowed,
             });
             continue;
@@ -1677,17 +1691,38 @@ fn apply_release_customization_overrides(
         let allowed = path_matches_any(&leaf.path, &allowed_paths)?;
         if denied || !allowed {
             ignored.push(IgnoredOverride {
-                path: leaf.path,
+                path: leaf.original_path,
                 reason: IgnoredOverrideReason::Disallowed,
             });
         } else {
-            applied.push(leaf);
+            match leaf.operation {
+                OverrideLeafOperation::Replace => replace_leaves.push(leaf),
+                OverrideLeafOperation::Append => {
+                    if is_supported_application_array_field_path(&leaf.path) {
+                        append_leaves.push(leaf);
+                    } else {
+                        ignored.push(IgnoredOverride {
+                            path: leaf.original_path,
+                            reason: IgnoredOverrideReason::Invalid,
+                        });
+                    }
+                }
+            }
         }
     }
 
-    if !applied.is_empty() {
-        let override_value = build_override_value(&applied);
+    if !replace_leaves.is_empty() {
+        let override_value = build_override_value(&replace_leaves);
         *app = deep_merge_value(Some(app.clone()), override_value);
+    }
+
+    for leaf in append_leaves {
+        if let Err(reason) = append_override_value(app, &leaf) {
+            ignored.push(IgnoredOverride {
+                path: leaf.original_path,
+                reason,
+            });
+        }
     }
 
     if !ignored.is_empty() {
@@ -1697,24 +1732,86 @@ fn apply_release_customization_overrides(
     Ok(())
 }
 
-fn flatten_override_leaves(value: &serde_json::Value, prefix: &mut Vec<String>, leaves: &mut Vec<OverrideLeaf>) {
+fn flatten_override_leaves(
+    value: &serde_json::Value,
+    original_prefix: &mut Vec<String>,
+    canonical_prefix: &mut Vec<String>,
+    operation: OverrideLeafOperation,
+    leaves: &mut Vec<OverrideLeaf>,
+) {
     if let serde_json::Value::Object(map) = value {
         if map.is_empty() {
             return;
         }
         for (key, child) in map {
-            prefix.push(key.clone());
-            flatten_override_leaves(child, prefix, leaves);
-            prefix.pop();
+            let (canonical_key, key_operation) = parse_override_key(key);
+            original_prefix.push(key.clone());
+            canonical_prefix.push(canonical_key);
+            if matches!(key_operation, OverrideLeafOperation::Append) {
+                leaves.push(OverrideLeaf {
+                    segments: canonical_prefix.clone(),
+                    path: join_field_path_segments(canonical_prefix),
+                    original_path: join_override_path_segments(original_prefix),
+                    value: child.clone(),
+                    operation: OverrideLeafOperation::Append,
+                });
+                canonical_prefix.pop();
+                original_prefix.pop();
+                continue;
+            }
+
+            flatten_override_leaves(child, original_prefix, canonical_prefix, operation.clone(), leaves);
+            canonical_prefix.pop();
+            original_prefix.pop();
         }
         return;
     }
 
     leaves.push(OverrideLeaf {
-        segments: prefix.clone(),
-        path: join_field_path_segments(prefix),
+        segments: canonical_prefix.clone(),
+        path: join_field_path_segments(canonical_prefix),
+        original_path: join_override_path_segments(original_prefix),
         value: value.clone(),
+        operation,
     });
+}
+
+fn parse_override_key(key: &str) -> (String, OverrideLeafOperation) {
+    if let Some(stripped) = key.strip_prefix('+') {
+        if !stripped.is_empty() {
+            return (stripped.to_string(), OverrideLeafOperation::Append);
+        }
+    }
+    (key.to_string(), OverrideLeafOperation::Replace)
+}
+
+fn join_override_path_segments(segments: &[String]) -> String {
+    segments
+        .iter()
+        .map(|segment| {
+            if is_simple_override_segment(segment) {
+                segment.clone()
+            } else {
+                let escaped = segment.replace('\\', "\\\\").replace('"', "\\\"");
+                format!("\"{}\"", escaped)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+fn is_simple_override_segment(segment: &str) -> bool {
+    if let Some(stripped) = segment.strip_prefix('+') {
+        return !stripped.is_empty()
+            && stripped
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-');
+    }
+
+    !segment.is_empty()
+        && segment
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
 }
 
 fn build_override_value(leaves: &[OverrideLeaf]) -> serde_json::Value {
@@ -1756,6 +1853,67 @@ fn path_matches_any(path: &str, patterns: &[impl AsRef<str>]) -> Result<bool> {
         }
     }
     Ok(false)
+}
+
+fn append_override_value(
+    app: &mut serde_json::Value,
+    leaf: &OverrideLeaf,
+) -> std::result::Result<(), IgnoredOverrideReason> {
+    let items = match &leaf.value {
+        serde_json::Value::Array(items) => items.clone(),
+        _ => return Err(IgnoredOverrideReason::Invalid),
+    };
+
+    append_override_items(app, &leaf.segments, items)
+}
+
+fn append_override_items(
+    current: &mut serde_json::Value,
+    segments: &[String],
+    items: Vec<serde_json::Value>,
+) -> std::result::Result<(), IgnoredOverrideReason> {
+    if segments.is_empty() {
+        return Err(IgnoredOverrideReason::Invalid);
+    }
+
+    if !current.is_object() {
+        if current.is_null() {
+            *current = serde_json::Value::Object(serde_json::Map::new());
+        } else {
+            return Err(IgnoredOverrideReason::Invalid);
+        }
+    }
+
+    let map = current.as_object_mut().ok_or(IgnoredOverrideReason::Invalid)?;
+
+    if segments.len() == 1 {
+        let entry = map
+            .entry(segments[0].clone())
+            .or_insert_with(|| serde_json::Value::Array(Vec::new()));
+        match entry {
+            serde_json::Value::Array(array) => {
+                array.extend(items);
+                Ok(())
+            }
+            serde_json::Value::Null => {
+                *entry = serde_json::Value::Array(items);
+                Ok(())
+            }
+            _ => Err(IgnoredOverrideReason::Invalid),
+        }
+    } else {
+        let entry = map
+            .entry(segments[0].clone())
+            .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+        if !entry.is_object() {
+            if entry.is_null() {
+                *entry = serde_json::Value::Object(serde_json::Map::new());
+            } else {
+                return Err(IgnoredOverrideReason::Invalid);
+            }
+        }
+        append_override_items(entry, &segments[1..], items)
+    }
 }
 
 fn append_customization_warning(app: &mut serde_json::Value, ignored: &[IgnoredOverride]) -> Result<()> {
@@ -1906,6 +2064,64 @@ mod tests {
         std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
         std::fs::write(&file_path, "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: test\n").unwrap();
         (temp, source_root, file_path)
+    }
+
+    fn test_release_with_override(override_value: serde_json::Value) -> NylRelease {
+        use crate::resources::{NylReleaseArgoCdSpec, NylReleaseMetadata, NylReleaseSpec};
+
+        NylRelease {
+            api_version: API_VERSION.to_string(),
+            kind: "NylRelease".to_string(),
+            metadata: NylReleaseMetadata {
+                name: "nginx".to_string(),
+                namespace: "web".to_string(),
+            },
+            spec: NylReleaseSpec {
+                argocd: Some(NylReleaseArgoCdSpec {
+                    application_override: Some(serde_json::from_value(override_value).unwrap()),
+                }),
+            },
+        }
+    }
+
+    fn test_application_generator(
+        sync_policy: Option<crate::resources::SyncPolicy>,
+        release_customization: Option<crate::resources::ReleaseCustomizationPolicy>,
+    ) -> crate::resources::ApplicationGenerator {
+        use crate::resources::{
+            ApplicationDestination, ApplicationGenerator, ApplicationGeneratorMetadata, ApplicationGeneratorSpec,
+            ApplicationSource,
+        };
+        use std::collections::HashMap;
+
+        ApplicationGenerator {
+            api_version: API_VERSION_ARGOCD.to_string(),
+            kind: "ApplicationGenerator".to_string(),
+            metadata: ApplicationGeneratorMetadata {
+                name: "apps".to_string(),
+                namespace: Some("argocd".to_string()),
+            },
+            spec: ApplicationGeneratorSpec {
+                destination: ApplicationDestination {
+                    server: "https://kubernetes.default.svc".to_string(),
+                    namespace: "argocd".to_string(),
+                },
+                source: ApplicationSource {
+                    repo_url: "https://github.com/example/repo.git".to_string(),
+                    target_revision: "HEAD".to_string(),
+                    path: Some("clusters/default".to_string()),
+                    paths: None,
+                    include: vec!["*.yaml".to_string()],
+                    exclude: vec![".*".to_string()],
+                },
+                project: "default".to_string(),
+                sync_policy,
+                application_name_template: "{{ .release.name }}".to_string(),
+                labels: HashMap::new(),
+                annotations: HashMap::new(),
+                release_customization,
+            },
+        }
     }
 
     fn test_application_generator_for_warning() -> crate::resources::ApplicationGenerator {
@@ -2225,6 +2441,96 @@ metadata:
     }
 
     #[test]
+    fn test_release_customization_plus_sync_options_uses_canonical_path_for_denies() {
+        use crate::resources::{ReleaseCustomizationPolicy, SyncPolicy};
+
+        let release = test_release_with_override(serde_json::json!({
+            "spec": {
+                "syncPolicy": {
+                    "+syncOptions": ["RespectIgnoreDifferences=false"]
+                }
+            }
+        }));
+        let generator = test_application_generator(
+            Some(SyncPolicy {
+                automated: None,
+                sync_options: vec!["ServerSideApply=true".to_string()],
+            }),
+            Some(ReleaseCustomizationPolicy {
+                allowed_paths: Some(vec!["spec.syncPolicy.**".to_string()]),
+                denied_paths: vec!["spec.syncPolicy.syncOptions".to_string()],
+            }),
+        );
+
+        let (_temp, source_root, file_path) = create_test_worktree_paths();
+        let app = create_argocd_application_from_generator(&release, &file_path, &source_root, &generator).unwrap();
+
+        assert_eq!(
+            app["spec"]["syncPolicy"]["syncOptions"],
+            serde_json::json!(["ServerSideApply=true"])
+        );
+        let warning = app["spec"]["info"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["name"] == NYL_CUSTOMIZATION_WARNING_NAME)
+            .and_then(|entry| entry["value"].as_str())
+            .unwrap();
+        assert!(warning.contains("+syncOptions"));
+    }
+
+    #[test]
+    fn test_release_customization_plus_sync_options_with_non_array_value_warns_and_ignores() {
+        let release = test_release_with_override(serde_json::json!({
+            "spec": {
+                "syncPolicy": {
+                    "+syncOptions": "RespectIgnoreDifferences=false"
+                }
+            }
+        }));
+        let generator = test_application_generator(None, None);
+
+        let (_temp, source_root, file_path) = create_test_worktree_paths();
+        let app = create_argocd_application_from_generator(&release, &file_path, &source_root, &generator).unwrap();
+
+        assert!(app["spec"]["syncPolicy"].is_null());
+        let warning = app["spec"]["info"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["name"] == NYL_CUSTOMIZATION_WARNING_NAME)
+            .and_then(|entry| entry["value"].as_str())
+            .unwrap();
+        assert!(warning.contains("invalid"));
+        assert!(warning.contains("+syncOptions"));
+    }
+
+    #[test]
+    fn test_release_customization_plus_non_array_field_warns_and_ignores() {
+        let release = test_release_with_override(serde_json::json!({
+            "spec": {
+                "syncPolicy": {
+                    "+automated": [{"prune": true}]
+                }
+            }
+        }));
+        let generator = test_application_generator(None, None);
+
+        let (_temp, source_root, file_path) = create_test_worktree_paths();
+        let app = create_argocd_application_from_generator(&release, &file_path, &source_root, &generator).unwrap();
+
+        assert!(app["spec"]["syncPolicy"]["automated"].is_null());
+        let warning = app["spec"]["info"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["name"] == NYL_CUSTOMIZATION_WARNING_NAME)
+            .and_then(|entry| entry["value"].as_str())
+            .unwrap();
+        assert!(warning.contains("+automated"));
+    }
+
+    #[test]
     fn test_release_customization_uses_default_allowed_paths() {
         use crate::resources::{
             ApplicationDestination, ApplicationGenerator, ApplicationGeneratorMetadata, ApplicationGeneratorSpec,
@@ -2361,6 +2667,108 @@ metadata:
         let app = create_argocd_application_from_generator(&release, &file_path, &source_root, &generator).unwrap();
 
         assert_eq!(app["spec"]["syncPolicy"]["automated"]["selfHeal"], true);
+    }
+
+    #[test]
+    fn test_release_customization_plus_sync_options_uses_canonical_path_for_policy_checks() {
+        let release = test_release_with_override(serde_json::json!({
+            "spec": {
+                "syncPolicy": {
+                    "+syncOptions": ["RespectIgnoreDifferences=false"]
+                }
+            }
+        }));
+        let generator = test_application_generator(
+            Some(crate::resources::SyncPolicy {
+                automated: None,
+                sync_options: vec!["ServerSideApply=true".to_string()],
+            }),
+            Some(crate::resources::ReleaseCustomizationPolicy {
+                allowed_paths: Some(vec!["spec.syncPolicy.syncOptions".to_string()]),
+                denied_paths: Vec::new(),
+            }),
+        );
+
+        let (_temp, source_root, file_path) = create_test_worktree_paths();
+        let app = create_argocd_application_from_generator(&release, &file_path, &source_root, &generator).unwrap();
+
+        assert_eq!(
+            app["spec"]["syncPolicy"]["syncOptions"],
+            serde_json::json!(["ServerSideApply=true", "RespectIgnoreDifferences=false"])
+        );
+        assert!(app["spec"]["info"].is_null());
+    }
+
+    #[test]
+    fn test_release_customization_invalid_plus_sync_options_warns_and_ignores_override() {
+        let release = test_release_with_override(serde_json::json!({
+            "spec": {
+                "syncPolicy": {
+                    "+syncOptions": {
+                        "bad": "value"
+                    }
+                }
+            }
+        }));
+        let generator = test_application_generator(
+            Some(crate::resources::SyncPolicy {
+                automated: None,
+                sync_options: vec!["ServerSideApply=true".to_string()],
+            }),
+            None,
+        );
+
+        let (_temp, source_root, file_path) = create_test_worktree_paths();
+        let app = create_argocd_application_from_generator(&release, &file_path, &source_root, &generator).unwrap();
+
+        assert_eq!(
+            app["spec"]["syncPolicy"]["syncOptions"],
+            serde_json::json!(["ServerSideApply=true"])
+        );
+        let warning = app["spec"]["info"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["name"] == NYL_CUSTOMIZATION_WARNING_NAME)
+            .unwrap();
+        let warning_value = warning["value"].as_str().unwrap();
+        assert!(warning_value.contains("invalid=1"));
+        assert!(warning_value.contains("+syncOptions"));
+    }
+
+    #[test]
+    fn test_release_customization_plus_sync_policy_warns_when_target_is_not_a_list() {
+        let release = test_release_with_override(serde_json::json!({
+            "spec": {
+                "+syncPolicy": [
+                    {"syncOptions": ["RespectIgnoreDifferences=false"]}
+                ]
+            }
+        }));
+        let generator = test_application_generator(
+            Some(crate::resources::SyncPolicy {
+                automated: None,
+                sync_options: vec!["ServerSideApply=true".to_string()],
+            }),
+            None,
+        );
+
+        let (_temp, source_root, file_path) = create_test_worktree_paths();
+        let app = create_argocd_application_from_generator(&release, &file_path, &source_root, &generator).unwrap();
+
+        assert_eq!(
+            app["spec"]["syncPolicy"]["syncOptions"],
+            serde_json::json!(["ServerSideApply=true"])
+        );
+        let warning = app["spec"]["info"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["name"] == NYL_CUSTOMIZATION_WARNING_NAME)
+            .unwrap();
+        let warning_value = warning["value"].as_str().unwrap();
+        assert!(warning_value.contains("invalid=1"));
+        assert!(warning_value.contains("+syncPolicy"));
     }
 
     #[test]

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -1532,7 +1532,7 @@ struct IgnoredOverride {
     reason: IgnoredOverrideReason,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 enum OverrideLeafOperation {
     Append,
     Replace,
@@ -1541,10 +1541,23 @@ enum OverrideLeafOperation {
 #[derive(Debug, Clone)]
 struct OverrideLeaf {
     segments: Vec<String>,
+    /// Canonical dotted path (without `+` prefixes), used for policy checks.
     path: String,
-    original_path: String,
+    /// Original key of the leaf segment (e.g. `+syncOptions`), used in warning messages.
+    original_key: String,
     value: serde_json::Value,
     operation: OverrideLeafOperation,
+}
+
+impl OverrideLeaf {
+    /// Return the display path for warning messages, using the original key (with `+` prefix if present).
+    fn display_path(&self) -> String {
+        let mut segments = self.segments.clone();
+        if let Some(last) = segments.last_mut() {
+            last.clone_from(&self.original_key);
+        }
+        join_field_path_segments(&segments)
+    }
 }
 
 /// Create ArgoCD Application from generator config
@@ -1640,13 +1653,10 @@ fn apply_release_customization_overrides(
     };
 
     let mut override_leaves = Vec::new();
-    let mut original_prefix = Vec::new();
-    let mut canonical_prefix = Vec::new();
+    let mut prefix = Vec::new();
     flatten_override_leaves(
         &serde_json::Value::Object(application_override),
-        &mut original_prefix,
-        &mut canonical_prefix,
-        OverrideLeafOperation::Replace,
+        &mut prefix,
         &mut override_leaves,
     );
 
@@ -1673,7 +1683,7 @@ fn apply_release_customization_overrides(
     for leaf in override_leaves {
         if !is_supported_application_field_path(&leaf.path) {
             ignored.push(IgnoredOverride {
-                path: leaf.original_path,
+                path: leaf.display_path(),
                 reason: IgnoredOverrideReason::Unsupported,
             });
             continue;
@@ -1681,7 +1691,7 @@ fn apply_release_customization_overrides(
 
         if path_matches_any(&leaf.path, IMMUTABLE_APPLICATION_PATH_PATTERNS)? {
             ignored.push(IgnoredOverride {
-                path: leaf.original_path,
+                path: leaf.display_path(),
                 reason: IgnoredOverrideReason::Disallowed,
             });
             continue;
@@ -1691,7 +1701,7 @@ fn apply_release_customization_overrides(
         let allowed = path_matches_any(&leaf.path, &allowed_paths)?;
         if denied || !allowed {
             ignored.push(IgnoredOverride {
-                path: leaf.original_path,
+                path: leaf.display_path(),
                 reason: IgnoredOverrideReason::Disallowed,
             });
         } else {
@@ -1702,7 +1712,7 @@ fn apply_release_customization_overrides(
                         append_leaves.push(leaf);
                     } else {
                         ignored.push(IgnoredOverride {
-                            path: leaf.original_path,
+                            path: leaf.display_path(),
                             reason: IgnoredOverrideReason::Invalid,
                         });
                     }
@@ -1717,9 +1727,17 @@ fn apply_release_customization_overrides(
     }
 
     for leaf in append_leaves {
-        if let Err(reason) = append_override_value(app, &leaf) {
+        let serde_json::Value::Array(items) = &leaf.value else {
             ignored.push(IgnoredOverride {
-                path: leaf.original_path,
+                path: leaf.display_path(),
+                reason: IgnoredOverrideReason::Invalid,
+            });
+            continue;
+        };
+        let items = items.clone();
+        if let Err(reason) = append_override_items(app, &leaf.segments, items) {
+            ignored.push(IgnoredOverride {
+                path: leaf.display_path(),
                 reason,
             });
         }
@@ -1732,47 +1750,36 @@ fn apply_release_customization_overrides(
     Ok(())
 }
 
-fn flatten_override_leaves(
-    value: &serde_json::Value,
-    original_prefix: &mut Vec<String>,
-    canonical_prefix: &mut Vec<String>,
-    operation: OverrideLeafOperation,
-    leaves: &mut Vec<OverrideLeaf>,
-) {
+fn flatten_override_leaves(value: &serde_json::Value, prefix: &mut Vec<String>, leaves: &mut Vec<OverrideLeaf>) {
     if let serde_json::Value::Object(map) = value {
         if map.is_empty() {
             return;
         }
         for (key, child) in map {
-            let (canonical_key, key_operation) = parse_override_key(key);
-            original_prefix.push(key.clone());
-            canonical_prefix.push(canonical_key);
-            if matches!(key_operation, OverrideLeafOperation::Append) {
+            let (canonical_key, operation) = parse_override_key(key);
+            prefix.push(canonical_key);
+            if matches!(operation, OverrideLeafOperation::Append) {
                 leaves.push(OverrideLeaf {
-                    segments: canonical_prefix.clone(),
-                    path: join_field_path_segments(canonical_prefix),
-                    original_path: join_override_path_segments(original_prefix),
+                    segments: prefix.clone(),
+                    path: join_field_path_segments(prefix),
+                    original_key: key.clone(),
                     value: child.clone(),
                     operation: OverrideLeafOperation::Append,
                 });
-                canonical_prefix.pop();
-                original_prefix.pop();
-                continue;
+            } else {
+                flatten_override_leaves(child, prefix, leaves);
             }
-
-            flatten_override_leaves(child, original_prefix, canonical_prefix, operation.clone(), leaves);
-            canonical_prefix.pop();
-            original_prefix.pop();
+            prefix.pop();
         }
         return;
     }
 
     leaves.push(OverrideLeaf {
-        segments: canonical_prefix.clone(),
-        path: join_field_path_segments(canonical_prefix),
-        original_path: join_override_path_segments(original_prefix),
+        segments: prefix.clone(),
+        path: join_field_path_segments(prefix),
+        original_key: prefix.last().cloned().unwrap_or_default(),
         value: value.clone(),
-        operation,
+        operation: OverrideLeafOperation::Replace,
     });
 }
 
@@ -1783,35 +1790,6 @@ fn parse_override_key(key: &str) -> (String, OverrideLeafOperation) {
         }
     }
     (key.to_string(), OverrideLeafOperation::Replace)
-}
-
-fn join_override_path_segments(segments: &[String]) -> String {
-    segments
-        .iter()
-        .map(|segment| {
-            if is_simple_override_segment(segment) {
-                segment.clone()
-            } else {
-                let escaped = segment.replace('\\', "\\\\").replace('"', "\\\"");
-                format!("\"{}\"", escaped)
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(".")
-}
-
-fn is_simple_override_segment(segment: &str) -> bool {
-    if let Some(stripped) = segment.strip_prefix('+') {
-        return !stripped.is_empty()
-            && stripped
-                .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-');
-    }
-
-    !segment.is_empty()
-        && segment
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
 }
 
 fn build_override_value(leaves: &[OverrideLeaf]) -> serde_json::Value {
@@ -1855,16 +1833,15 @@ fn path_matches_any(path: &str, patterns: &[impl AsRef<str>]) -> Result<bool> {
     Ok(false)
 }
 
-fn append_override_value(
-    app: &mut serde_json::Value,
-    leaf: &OverrideLeaf,
-) -> std::result::Result<(), IgnoredOverrideReason> {
-    let items = match &leaf.value {
-        serde_json::Value::Array(items) => items.clone(),
-        _ => return Err(IgnoredOverrideReason::Invalid),
-    };
-
-    append_override_items(app, &leaf.segments, items)
+fn coerce_to_object(value: &mut serde_json::Value) -> std::result::Result<(), IgnoredOverrideReason> {
+    match value {
+        serde_json::Value::Object(_) => Ok(()),
+        serde_json::Value::Null => {
+            *value = serde_json::Value::Object(serde_json::Map::new());
+            Ok(())
+        }
+        _ => Err(IgnoredOverrideReason::Invalid),
+    }
 }
 
 fn append_override_items(
@@ -1876,15 +1853,8 @@ fn append_override_items(
         return Err(IgnoredOverrideReason::Invalid);
     }
 
-    if !current.is_object() {
-        if current.is_null() {
-            *current = serde_json::Value::Object(serde_json::Map::new());
-        } else {
-            return Err(IgnoredOverrideReason::Invalid);
-        }
-    }
-
-    let map = current.as_object_mut().ok_or(IgnoredOverrideReason::Invalid)?;
+    coerce_to_object(current)?;
+    let map = current.as_object_mut().unwrap();
 
     if segments.len() == 1 {
         let entry = map
@@ -1905,13 +1875,7 @@ fn append_override_items(
         let entry = map
             .entry(segments[0].clone())
             .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
-        if !entry.is_object() {
-            if entry.is_null() {
-                *entry = serde_json::Value::Object(serde_json::Map::new());
-            } else {
-                return Err(IgnoredOverrideReason::Invalid);
-            }
-        }
+        coerce_to_object(entry)?;
         append_override_items(entry, &segments[1..], items)
     }
 }

--- a/nyl/src/resources/argocd_application_field_catalog.rs
+++ b/nyl/src/resources/argocd_application_field_catalog.rs
@@ -95,6 +95,17 @@ mod tests {
     }
 
     #[test]
+    fn test_array_field_patterns_are_subset_of_path_patterns() {
+        for pattern in VALID_APPLICATION_ARRAY_FIELD_PATTERNS {
+            assert!(
+                is_supported_application_field_path(pattern),
+                "array field pattern '{}' is not covered by VALID_APPLICATION_PATH_PATTERNS",
+                pattern
+            );
+        }
+    }
+
+    #[test]
     fn test_field_catalog_patterns_are_valid() {
         for pattern in VALID_APPLICATION_PATH_PATTERNS {
             validate_path_glob_pattern(pattern).unwrap_or_else(|e| {

--- a/nyl/src/resources/argocd_application_field_catalog.rs
+++ b/nyl/src/resources/argocd_application_field_catalog.rs
@@ -33,8 +33,34 @@ const VALID_APPLICATION_PATH_PATTERNS: &[&str] = &[
     "spec.info.**",
 ];
 
+/// Known ArgoCD Application field-path patterns whose values are arrays and can
+/// therefore support `+field` append semantics in NylRelease overrides.
+const VALID_APPLICATION_ARRAY_FIELD_PATTERNS: &[&str] = &[
+    "metadata.finalizers",
+    "spec.source.helm.valueFiles",
+    "spec.source.helm.parameters",
+    "spec.source.helm.fileParameters",
+    "spec.source.kustomize.images",
+    "spec.source.kustomize.replicas",
+    "spec.source.kustomize.components",
+    "spec.source.kustomize.patches",
+    "spec.source.jsonnet.extVars",
+    "spec.source.jsonnet.tlas",
+    "spec.source.plugin.env",
+    "spec.sources",
+    "spec.syncPolicy.syncOptions",
+    "spec.ignoreDifferences",
+    "spec.info",
+];
+
 pub fn is_supported_application_field_path(path: &str) -> bool {
     VALID_APPLICATION_PATH_PATTERNS
+        .iter()
+        .any(|pattern| path_matches_glob(path, pattern).unwrap_or(false))
+}
+
+pub fn is_supported_application_array_field_path(path: &str) -> bool {
+    VALID_APPLICATION_ARRAY_FIELD_PATTERNS
         .iter()
         .any(|pattern| path_matches_glob(path, pattern).unwrap_or(false))
 }
@@ -58,10 +84,26 @@ mod tests {
     }
 
     #[test]
+    fn test_supported_array_field_path() {
+        assert!(is_supported_application_array_field_path("spec.syncPolicy.syncOptions"));
+        assert!(is_supported_application_array_field_path("spec.info"));
+    }
+
+    #[test]
+    fn test_unsupported_array_field_path() {
+        assert!(!is_supported_application_array_field_path("spec.syncPolicy.automated"));
+    }
+
+    #[test]
     fn test_field_catalog_patterns_are_valid() {
         for pattern in VALID_APPLICATION_PATH_PATTERNS {
             validate_path_glob_pattern(pattern).unwrap_or_else(|e| {
                 panic!("invalid field catalog pattern '{}': {}", pattern, e);
+            });
+        }
+        for pattern in VALID_APPLICATION_ARRAY_FIELD_PATTERNS {
+            validate_path_glob_pattern(pattern).unwrap_or_else(|e| {
+                panic!("invalid array field catalog pattern '{}': {}", pattern, e);
             });
         }
     }

--- a/nyl/src/resources/mod.rs
+++ b/nyl/src/resources/mod.rs
@@ -14,7 +14,9 @@ pub use application_generator::{
     extract_application_generators, ApplicationDestination, ApplicationGenerator, ApplicationGeneratorMetadata,
     ApplicationGeneratorSpec, ApplicationSource, AutomatedSyncPolicy, ReleaseCustomizationPolicy, SyncPolicy,
 };
-pub use argocd_application_field_catalog::is_supported_application_field_path;
+pub use argocd_application_field_catalog::{
+    is_supported_application_array_field_path, is_supported_application_field_path,
+};
 pub use component::{
     component_kind_to_chart_ref, is_nyl_component, is_remote_helm_chart_shortcut, parse_component_kind,
     ComponentKindParsed, NylComponent,


### PR DESCRIPTION
## Summary
- support +<field> append semantics in NylRelease.spec.argocd.applicationOverride
- validate append overrides against canonical ArgoCD Application paths and restrict appends to list-valued fields
- document +syncOptions usage and add coverage for append, policy, and invalid-append behavior

## Testing
- mise run pre-commit