### PR TITLE
feat: add configurable empty metadata label stripping

### DIFF
--- a/nyl/book/src/reference/schemas/nyl.schema.json
+++ b/nyl/book/src/reference/schemas/nyl.schema.json
@@ -49,9 +49,44 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "strip_empty_metadata_labels": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/StripEmptyMetadataLabelsMode"
+            }
+          ],
+          "default": "always",
+          "description": "Control when empty `metadata.labels` maps are stripped from emitted manifests."
         }
       },
       "type": "object"
+    },
+    "StripEmptyMetadataLabelsMode": {
+      "description": "Controls when empty `metadata.labels` maps are stripped from emitted manifests.",
+      "oneOf": [
+        {
+          "description": "Always strip empty `metadata.labels` maps from emitted manifests.",
+          "enum": [
+            "always"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Never strip empty `metadata.labels` maps from emitted manifests.",
+          "enum": [
+            "never"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Strip empty `metadata.labels` maps only when running in an ArgoCD environment.",
+          "enum": [
+            "argocd"
+          ],
+          "type": "string"
+        }
+      ]
     }
   },
   "description": "Root structure of `nyl.toml`.",
@@ -79,7 +114,8 @@
         ],
         "helm_chart_search_paths": [
           "."
-        ]
+        ],
+        "strip_empty_metadata_labels": "always"
       }
     }
   },

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -174,8 +174,6 @@ pub async fn run_render_preflight(options: RenderPreflightOptions<'_>) -> Result
         }
     }
 
-    normalize_emitted_manifests(&mut manifests);
-
     Ok(RenderPreflightResult {
         manifests,
         nyl_release,
@@ -444,10 +442,16 @@ fn should_initialize_cluster_clients(
             || (resolve_namespaces && should_resolve_namespaces(manifests, offline)))
 }
 
-pub(crate) fn normalize_emitted_manifests(manifests: &mut [serde_json::Value]) {
+fn normalize_emitted_manifests(manifests: &mut [serde_json::Value]) {
     for manifest in manifests {
         strip_empty_metadata_labels(manifest);
     }
+}
+
+fn prepare_manifests_for_output(manifests: &[serde_json::Value]) -> Vec<serde_json::Value> {
+    let mut emitted_manifests = manifests.to_vec();
+    normalize_emitted_manifests(&mut emitted_manifests);
+    emitted_manifests
 }
 
 fn strip_empty_metadata_labels(manifest: &mut serde_json::Value) {
@@ -1095,6 +1099,8 @@ fn render_helm_chart(
 
 /// Output manifests in the specified format
 fn output_manifests(manifests: &[serde_json::Value], format: OutputFormat) -> Result<()> {
+    let manifests = prepare_manifests_for_output(manifests);
+
     match format {
         OutputFormat::Yaml => {
             for (i, manifest) in manifests.iter().enumerate() {
@@ -1106,7 +1112,7 @@ fn output_manifests(manifests: &[serde_json::Value], format: OutputFormat) -> Re
             }
         }
         OutputFormat::Json => {
-            let json = serde_json::to_string_pretty(manifests)
+            let json = serde_json::to_string_pretty(&manifests)
                 .map_err(|e| NylError::Config(format!("Failed to serialize JSON: {}", e)))?;
             println!("{}", json);
         }
@@ -3959,7 +3965,7 @@ metadata:
 
     #[test]
     fn test_normalize_emitted_manifests_removes_empty_labels_from_emitted_yaml() {
-        let mut manifests = vec![serde_json::json!({
+        let original = vec![serde_json::json!({
             "apiVersion": "v1",
             "kind": "ConfigMap",
             "metadata": {
@@ -3968,12 +3974,30 @@ metadata:
             }
         })];
 
-        normalize_emitted_manifests(&mut manifests);
+        let manifests = prepare_manifests_for_output(&original);
 
         let yaml = crate::yaml::serialize_yaml_document(&manifests[0]).unwrap();
         assert!(!yaml.contains("labels: {}"));
         assert!(!yaml.contains("labels:\n"));
         assert!(yaml.contains("name: cm"));
+        assert_eq!(original[0]["metadata"]["labels"], serde_json::json!({}));
+    }
+
+    #[test]
+    fn test_prepare_manifests_for_output_preserves_original_manifests() {
+        let original = vec![serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+                "name": "cm",
+                "labels": {}
+            }
+        })];
+
+        let emitted = prepare_manifests_for_output(&original);
+
+        assert_eq!(original[0]["metadata"]["labels"], serde_json::json!({}));
+        assert!(emitted[0]["metadata"]["labels"].is_null());
     }
 
     #[test]

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -9,8 +9,9 @@ use std::time::Duration;
 
 use crate::{
     cli::namespace_resolution::{adjust_duplicate_keys_for_namespace_resolution, resolve_manifest_namespaces},
-    config::ProjectConfig,
+    config::{ProjectConfig, StripEmptyMetadataLabelsMode},
     constants::{API_VERSION, API_VERSION_ARGOCD, API_VERSION_COMPONENTS},
+    git::is_argocd_env,
     helm::{HelmChartResolver, HelmTemplateExecutor},
     kubernetes::{KubeClient, KubeRsClient, ResourceKey},
     postprocess::apply_kyverno_policies,
@@ -113,6 +114,7 @@ pub struct RenderPreflightOptions<'a> {
 pub struct RenderPreflightResult {
     pub manifests: Vec<serde_json::Value>,
     pub nyl_release: Option<NylRelease>,
+    pub strip_empty_metadata_labels: bool,
     pub profile: Profile,
     pub env_name: String,
     pub duplicates: HashMap<ResourceKey, usize>,
@@ -122,17 +124,18 @@ pub struct RenderPreflightResult {
 
 #[allow(clippy::too_many_lines)]
 pub async fn run_render_preflight(options: RenderPreflightOptions<'_>) -> Result<RenderPreflightResult> {
-    let (mut manifests, nyl_release, profile, env_name, mut duplicates) = render_manifests_complete(
-        &options.common.path,
-        options.common.only_source_kind.as_deref(),
-        options.common.profile.as_deref(),
-        options.offline,
-        options.kube_version,
-        options.kube_api_versions,
-        options.common.max_depth,
-        options.common.track_parent,
-    )
-    .await?;
+    let (mut manifests, nyl_release, strip_empty_metadata_labels_mode, profile, env_name, mut duplicates) =
+        render_manifests_complete(
+            &options.common.path,
+            options.common.only_source_kind.as_deref(),
+            options.common.profile.as_deref(),
+            options.offline,
+            options.kube_version,
+            options.kube_api_versions,
+            options.common.max_depth,
+            options.common.track_parent,
+        )
+        .await?;
 
     manifests = crate::cli::filter::filter_manifests_by_kind(
         manifests,
@@ -177,6 +180,7 @@ pub async fn run_render_preflight(options: RenderPreflightOptions<'_>) -> Result
     Ok(RenderPreflightResult {
         manifests,
         nyl_release,
+        strip_empty_metadata_labels: strip_empty_metadata_labels_mode.should_strip(is_argocd_env()),
         profile,
         env_name,
         duplicates,
@@ -188,7 +192,7 @@ pub async fn run_render_preflight(options: RenderPreflightOptions<'_>) -> Result
 /// Complete manifest rendering pipeline used by render, diff, and apply.
 /// Returns final manifests ready for output/apply/diff, with all Nyl resources processed.
 /// Also returns the extracted NylRelease metadata (if present) for diff/apply commands.
-/// Returns: (manifests, nyl_release, profile, env_name, duplicate_resources)
+/// Returns: (manifests, nyl_release, strip_empty_metadata_labels_mode, profile, env_name, duplicate_resources)
 #[allow(clippy::too_many_arguments)]
 pub async fn render_manifests_complete(
     path: &str,
@@ -202,12 +206,13 @@ pub async fn render_manifests_complete(
 ) -> Result<(
     Vec<serde_json::Value>,
     Option<NylRelease>,
+    StripEmptyMetadataLabelsMode,
     Profile,
     String,
     std::collections::HashMap<ResourceKey, usize>,
 )> {
     // 1. Render manifests (base pipeline)
-    let (manifests, profile, env_name, credential_provider) = render_manifests(
+    let (manifests, strip_empty_metadata_labels_mode, profile, env_name, credential_provider) = render_manifests(
         path,
         only_source_kind,
         environment,
@@ -221,6 +226,8 @@ pub async fn render_manifests_complete(
 
     // 2. Extract NylRelease metadata (before filtering it out)
     let (nyl_release, manifests) = extract_nyl_release(&manifests)?;
+    let strip_empty_metadata_labels_mode =
+        resolve_strip_empty_metadata_labels_mode(strip_empty_metadata_labels_mode, nyl_release.as_ref());
 
     // 3. Extract ApplicationGenerator resources and replace with ArgoCD Applications
     let (generators, mut final_manifests) = extract_application_generators(&manifests)?;
@@ -266,11 +273,18 @@ pub async fn render_manifests_complete(
     // 5. Detect and deduplicate resources (after all generation/transformation is complete)
     let (final_manifests, duplicates) = deduplicate_manifests(final_manifests)?;
 
-    Ok((final_manifests, nyl_release, profile, env_name, duplicates))
+    Ok((
+        final_manifests,
+        nyl_release,
+        strip_empty_metadata_labels_mode,
+        profile,
+        env_name,
+        duplicates,
+    ))
 }
 
 /// Shared manifest rendering logic used by render, diff, and apply
-/// Returns: (manifests, profile, env_name)
+/// Returns: (manifests, strip_empty_metadata_labels_mode, profile, env_name)
 #[allow(clippy::too_many_arguments)]
 pub async fn render_manifests(
     path: &str,
@@ -283,6 +297,7 @@ pub async fn render_manifests(
     track_parent: bool,
 ) -> Result<(
     Vec<serde_json::Value>,
+    StripEmptyMetadataLabelsMode,
     Profile,
     String,
     Option<Arc<crate::git::CredentialProvider>>,
@@ -370,7 +385,13 @@ pub async fn render_manifests(
     // This happens when max_depth is reached before all resources are expanded
     all_manifests.extend(pending);
 
-    Ok((all_manifests, profile, profile_name, credential_provider))
+    Ok((
+        all_manifests,
+        project_config.get_strip_empty_metadata_labels_mode(),
+        profile,
+        profile_name,
+        credential_provider,
+    ))
 }
 
 fn select_profile_from_project(project_config: &ProjectConfig, requested: Option<&str>) -> Result<(Profile, String)> {
@@ -421,7 +442,11 @@ pub async fn execute(args: RenderArgs) -> Result<()> {
         );
     }
 
-    output_manifests(&preflight.manifests, OutputFormat::Yaml)?;
+    output_manifests(
+        &preflight.manifests,
+        OutputFormat::Yaml,
+        preflight.strip_empty_metadata_labels,
+    )?;
     Ok(())
 }
 
@@ -448,9 +473,23 @@ fn normalize_emitted_manifests(manifests: &mut [serde_json::Value]) {
     }
 }
 
-fn prepare_manifests_for_output(manifests: &[serde_json::Value]) -> Vec<serde_json::Value> {
+fn resolve_strip_empty_metadata_labels_mode(
+    project_mode: StripEmptyMetadataLabelsMode,
+    release: Option<&NylRelease>,
+) -> StripEmptyMetadataLabelsMode {
+    release
+        .and_then(|release| release.spec.strip_empty_metadata_labels)
+        .unwrap_or(project_mode)
+}
+
+fn prepare_manifests_for_output(
+    manifests: &[serde_json::Value],
+    strip_empty_metadata_labels: bool,
+) -> Vec<serde_json::Value> {
     let mut emitted_manifests = manifests.to_vec();
-    normalize_emitted_manifests(&mut emitted_manifests);
+    if strip_empty_metadata_labels {
+        normalize_emitted_manifests(&mut emitted_manifests);
+    }
     emitted_manifests
 }
 
@@ -1098,8 +1137,12 @@ fn render_helm_chart(
 }
 
 /// Output manifests in the specified format
-fn output_manifests(manifests: &[serde_json::Value], format: OutputFormat) -> Result<()> {
-    let manifests = prepare_manifests_for_output(manifests);
+fn output_manifests(
+    manifests: &[serde_json::Value],
+    format: OutputFormat,
+    strip_empty_metadata_labels: bool,
+) -> Result<()> {
+    let manifests = prepare_manifests_for_output(manifests, strip_empty_metadata_labels);
 
     match format {
         OutputFormat::Yaml => {
@@ -2184,6 +2227,7 @@ fn add_parent_annotations(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::StripEmptyMetadataLabelsMode;
     use crate::resources::{
         ApplicationDestination, ApplicationGenerator, ApplicationGeneratorMetadata, ApplicationGeneratorSpec,
         ApplicationSource, NylReleaseArgoCdSpec, NylReleaseMetadata, NylReleaseSpec, ReleaseCustomizationPolicy,
@@ -2225,6 +2269,7 @@ mod tests {
                 namespace: "web".to_string(),
             },
             spec: NylReleaseSpec {
+                strip_empty_metadata_labels: None,
                 argocd: Some(NylReleaseArgoCdSpec {
                     application_override: Some(serde_json::from_value(override_value).unwrap()),
                 }),
@@ -2606,6 +2651,7 @@ metadata:
                 namespace: "web".to_string(),
             },
             spec: NylReleaseSpec {
+                strip_empty_metadata_labels: None,
                 argocd: Some(NylReleaseArgoCdSpec {
                     application_override: Some(serde_json::from_value(override_map).unwrap()),
                 }),
@@ -3974,7 +4020,7 @@ metadata:
             }
         })];
 
-        let manifests = prepare_manifests_for_output(&original);
+        let manifests = prepare_manifests_for_output(&original, true);
 
         let yaml = crate::yaml::serialize_yaml_document(&manifests[0]).unwrap();
         assert!(!yaml.contains("labels: {}"));
@@ -3994,10 +4040,65 @@ metadata:
             }
         })];
 
-        let emitted = prepare_manifests_for_output(&original);
+        let emitted = prepare_manifests_for_output(&original, true);
 
         assert_eq!(original[0]["metadata"]["labels"], serde_json::json!({}));
         assert!(emitted[0]["metadata"]["labels"].is_null());
+    }
+
+    #[test]
+    fn test_prepare_manifests_for_output_preserves_empty_labels_when_disabled() {
+        let original = vec![serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+                "name": "cm",
+                "labels": {}
+            }
+        })];
+
+        let emitted = prepare_manifests_for_output(&original, false);
+
+        assert_eq!(emitted[0]["metadata"]["labels"], serde_json::json!({}));
+    }
+
+    #[test]
+    fn test_resolve_strip_empty_metadata_labels_mode_uses_project_default() {
+        assert_eq!(
+            resolve_strip_empty_metadata_labels_mode(StripEmptyMetadataLabelsMode::Argocd, None),
+            StripEmptyMetadataLabelsMode::Argocd
+        );
+    }
+
+    #[test]
+    fn test_resolve_strip_empty_metadata_labels_mode_release_override_takes_precedence() {
+        let release = NylRelease {
+            api_version: API_VERSION.to_string(),
+            kind: "NylRelease".to_string(),
+            metadata: NylReleaseMetadata {
+                name: "nginx".to_string(),
+                namespace: "web".to_string(),
+            },
+            spec: NylReleaseSpec {
+                strip_empty_metadata_labels: Some(StripEmptyMetadataLabelsMode::Never),
+                argocd: Some(NylReleaseArgoCdSpec {
+                    application_override: None,
+                }),
+            },
+        };
+
+        assert_eq!(
+            resolve_strip_empty_metadata_labels_mode(StripEmptyMetadataLabelsMode::Always, Some(&release)),
+            StripEmptyMetadataLabelsMode::Never
+        );
+    }
+
+    #[test]
+    fn test_strip_empty_metadata_labels_mode_should_strip_respects_argocd_environment() {
+        assert!(StripEmptyMetadataLabelsMode::Always.should_strip(false));
+        assert!(!StripEmptyMetadataLabelsMode::Never.should_strip(true));
+        assert!(StripEmptyMetadataLabelsMode::Argocd.should_strip(true));
+        assert!(!StripEmptyMetadataLabelsMode::Argocd.should_strip(false));
     }
 
     #[test]

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -174,6 +174,8 @@ pub async fn run_render_preflight(options: RenderPreflightOptions<'_>) -> Result
         }
     }
 
+    normalize_emitted_manifests(&mut manifests);
+
     Ok(RenderPreflightResult {
         manifests,
         nyl_release,
@@ -440,6 +442,27 @@ fn should_initialize_cluster_clients(
         && (cluster_client_requirement == ClusterClientRequirement::Required
             || adjust_duplicate_keys
             || (resolve_namespaces && should_resolve_namespaces(manifests, offline)))
+}
+
+pub(crate) fn normalize_emitted_manifests(manifests: &mut [serde_json::Value]) {
+    for manifest in manifests {
+        strip_empty_metadata_labels(manifest);
+    }
+}
+
+fn strip_empty_metadata_labels(manifest: &mut serde_json::Value) {
+    let Some(metadata) = manifest.get_mut("metadata").and_then(|value| value.as_object_mut()) else {
+        return;
+    };
+
+    let should_remove = metadata
+        .get("labels")
+        .and_then(|value| value.as_object())
+        .is_some_and(serde_json::Map::is_empty);
+
+    if should_remove {
+        metadata.remove("labels");
+    }
 }
 
 fn manifest_requires_namespace_resolution(manifest: &serde_json::Value) -> bool {
@@ -3572,6 +3595,88 @@ metadata:
         assert_eq!(subjects[0]["namespace"], "target");
         assert_eq!(subjects[1]["namespace"], "target");
         assert!(subjects[2]["namespace"].is_null());
+    }
+
+    #[test]
+    fn test_normalize_emitted_manifests_strips_empty_metadata_labels() {
+        let mut manifests = vec![serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+                "name": "cm",
+                "labels": {}
+            }
+        })];
+
+        normalize_emitted_manifests(&mut manifests);
+
+        let metadata = manifests[0]["metadata"].as_object().unwrap();
+        assert!(!metadata.contains_key("labels"));
+    }
+
+    #[test]
+    fn test_normalize_emitted_manifests_preserves_non_empty_metadata_labels() {
+        let mut manifests = vec![serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+                "name": "cm",
+                "labels": {"app": "demo"}
+            }
+        })];
+
+        normalize_emitted_manifests(&mut manifests);
+
+        assert_eq!(manifests[0]["metadata"]["labels"]["app"], "demo");
+    }
+
+    #[test]
+    fn test_normalize_emitted_manifests_leaves_missing_metadata_unchanged() {
+        let original = serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "ConfigMap"
+        });
+        let mut manifests = vec![original.clone()];
+
+        normalize_emitted_manifests(&mut manifests);
+
+        assert_eq!(manifests[0], original);
+    }
+
+    #[test]
+    fn test_normalize_emitted_manifests_leaves_non_object_labels_unchanged() {
+        let original = serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+                "name": "cm",
+                "labels": "unexpected"
+            }
+        });
+        let mut manifests = vec![original.clone()];
+
+        normalize_emitted_manifests(&mut manifests);
+
+        assert_eq!(manifests[0], original);
+    }
+
+    #[test]
+    fn test_normalize_emitted_manifests_removes_empty_labels_from_emitted_yaml() {
+        let mut manifests = vec![serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+                "name": "cm",
+                "labels": {}
+            }
+        })];
+
+        normalize_emitted_manifests(&mut manifests);
+
+        let yaml = crate::yaml::serialize_yaml_document(&manifests[0]).unwrap();
+        assert!(!yaml.contains("labels: {}"));
+        assert!(!yaml.contains("labels:\n"));
+        assert!(yaml.contains("name: cm"));
     }
 
     #[test]

--- a/nyl/src/config/mod.rs
+++ b/nyl/src/config/mod.rs
@@ -29,6 +29,32 @@ fn default_profile_values() -> BTreeMap<String, BTreeMap<String, serde_json::Val
     BTreeMap::new()
 }
 
+/// Controls when empty `metadata.labels` maps are stripped from emitted manifests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum StripEmptyMetadataLabelsMode {
+    /// Always strip empty `metadata.labels` maps from emitted manifests.
+    #[default]
+    Always,
+
+    /// Never strip empty `metadata.labels` maps from emitted manifests.
+    Never,
+
+    /// Strip empty `metadata.labels` maps only when running in an ArgoCD environment.
+    Argocd,
+}
+
+impl StripEmptyMetadataLabelsMode {
+    /// Return whether empty metadata labels should be stripped for the current environment.
+    pub fn should_strip(self, is_argocd: bool) -> bool {
+        match self {
+            Self::Always => true,
+            Self::Never => false,
+            Self::Argocd => is_argocd,
+        }
+    }
+}
+
 /// Project settings in `[project]` section of `nyl.toml`.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(default, deny_unknown_fields)]
@@ -42,6 +68,9 @@ pub struct ProjectSettings {
     /// Aliases for component-like resources keyed as `<apiVersion>/<kind>`.
     /// Values are component kind targets (local component path or remote shortcut URL).
     pub aliases: BTreeMap<String, String>,
+
+    /// Control when empty `metadata.labels` maps are stripped from emitted manifests.
+    pub strip_empty_metadata_labels: StripEmptyMetadataLabelsMode,
 }
 
 impl Default for ProjectSettings {
@@ -50,6 +79,7 @@ impl Default for ProjectSettings {
             components_search_paths: default_components_search_paths(),
             helm_chart_search_paths: default_helm_chart_search_paths(),
             aliases: default_aliases(),
+            strip_empty_metadata_labels: StripEmptyMetadataLabelsMode::default(),
         }
     }
 }
@@ -243,6 +273,11 @@ impl ProjectConfig {
         self.get_alias_target(&key)
     }
 
+    /// Return the configured empty-label stripping mode for emitted manifests.
+    pub fn get_strip_empty_metadata_labels_mode(&self) -> StripEmptyMetadataLabelsMode {
+        self.config.project.strip_empty_metadata_labels
+    }
+
     /// Return whether any profile values are configured.
     pub fn has_profiles(&self) -> bool {
         !self.config.profile.values.is_empty()
@@ -320,6 +355,10 @@ mod tests {
         assert_eq!(settings.components_search_paths, vec![PathBuf::from("components")]);
         assert_eq!(settings.helm_chart_search_paths, vec![PathBuf::from(".")]);
         assert!(settings.aliases.is_empty());
+        assert_eq!(
+            settings.strip_empty_metadata_labels,
+            StripEmptyMetadataLabelsMode::Always
+        );
     }
 
     #[test]
@@ -337,6 +376,7 @@ mod tests {
 [project]
 components_search_paths = ["my-components"]
 helm_chart_search_paths = ["lib", "vendor"]
+strip_empty_metadata_labels = "argocd"
 [project.aliases]
 "myapi.io/v1/MyKind" = "oci://registry-1.docker.io/bitnamicharts/nginx@18.2.4"
 "#;
@@ -350,6 +390,10 @@ helm_chart_search_paths = ["lib", "vendor"]
         assert_eq!(
             config.get_alias_target_for_kind("myapi.io/v1", "MyKind"),
             Some("oci://registry-1.docker.io/bitnamicharts/nginx@18.2.4")
+        );
+        assert_eq!(
+            config.get_strip_empty_metadata_labels_mode(),
+            StripEmptyMetadataLabelsMode::Argocd
         );
         assert!(config.get_components_search_paths()[0].is_absolute());
         assert!(config.get_helm_chart_search_paths()[0].is_absolute());
@@ -365,6 +409,10 @@ helm_chart_search_paths = ["lib", "vendor"]
         assert_eq!(config.get_components_search_paths(), &[PathBuf::from("components")]);
         assert_eq!(config.get_helm_chart_search_paths(), &[PathBuf::from(".")]);
         assert!(config.config.project.aliases.is_empty());
+        assert_eq!(
+            config.get_strip_empty_metadata_labels_mode(),
+            StripEmptyMetadataLabelsMode::Always
+        );
         assert!(!config.has_profiles());
     }
 
@@ -503,5 +551,21 @@ replicas = 1
 
         let err = ProjectConfig::load(Some(config_path)).unwrap_err().to_string();
         assert!(err.contains("Failed to parse TOML config"));
+    }
+
+    #[test]
+    fn test_invalid_strip_empty_metadata_labels_mode_rejected() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join("nyl.toml");
+
+        let toml_content = r#"
+[project]
+strip_empty_metadata_labels = "sometimes"
+"#;
+        fs::write(&config_path, toml_content).unwrap();
+
+        let err = ProjectConfig::load(Some(config_path)).unwrap_err().to_string();
+        assert!(err.contains("Failed to parse TOML config"));
+        assert!(err.contains("strip_empty_metadata_labels"));
     }
 }

--- a/nyl/src/git/mod.rs
+++ b/nyl/src/git/mod.rs
@@ -58,7 +58,7 @@ use std::collections::HashMap;
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-fn is_argocd_env() -> bool {
+pub(crate) fn is_argocd_env() -> bool {
     std::env::var_os("ARGOCD_APP_NAME").is_some() || std::env::var_os("ARGOCD_APP_NAMESPACE").is_some()
 }
 

--- a/nyl/src/resources/nyl_release.rs
+++ b/nyl/src/resources/nyl_release.rs
@@ -5,6 +5,7 @@
 /// When absent, these values must be provided via CLI flags.
 use serde::{Deserialize, Deserializer, Serialize};
 
+use crate::config::StripEmptyMetadataLabelsMode;
 use crate::constants::API_VERSION;
 use crate::{NylError, Result};
 
@@ -34,6 +35,14 @@ pub struct NylReleaseMetadata {
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct NylReleaseSpec {
+    /// Control when empty `metadata.labels` maps are stripped from emitted manifests.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "stripEmptyMetadataLabels"
+    )]
+    pub strip_empty_metadata_labels: Option<StripEmptyMetadataLabelsMode>,
+
     /// ArgoCD-specific options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub argocd: Option<NylReleaseArgoCdSpec>,
@@ -197,6 +206,7 @@ mod tests {
                 "namespace": "production"
             },
             "spec": {
+                "stripEmptyMetadataLabels": "never",
                 "argocd": {
                     "applicationOverride": {
                         "spec": {
@@ -215,9 +225,14 @@ mod tests {
         let application_override = release
             .spec
             .argocd
-            .and_then(|a| a.application_override)
+            .as_ref()
+            .and_then(|a| a.application_override.clone())
             .expect("applicationOverride should be parsed");
         assert!(application_override.contains_key("spec"));
+        assert_eq!(
+            release.spec.strip_empty_metadata_labels,
+            Some(StripEmptyMetadataLabelsMode::Never)
+        );
     }
 
     #[test]
@@ -339,5 +354,23 @@ spec:
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("applicationOverride must be a YAML/JSON object"));
+    }
+
+    #[test]
+    fn test_nyl_release_parses_strip_empty_metadata_labels_override() {
+        let yaml = r"
+apiVersion: nyl.niklasrosenstein.github.com/v1
+kind: NylRelease
+metadata:
+  name: test
+  namespace: default
+spec:
+  stripEmptyMetadataLabels: argocd
+";
+        let release: NylRelease = serde_norway::from_str(yaml).unwrap();
+        assert_eq!(
+            release.spec.strip_empty_metadata_labels,
+            Some(StripEmptyMetadataLabelsMode::Argocd)
+        );
     }
 }


### PR DESCRIPTION
## Summary
- keep empty `metadata.labels` stripping on the render output path so `diff` and `apply` still use the original manifests
- add `[project].strip_empty_metadata_labels` with `always`, `never`, and `argocd` modes
- add `NylRelease.spec.stripEmptyMetadataLabels` as a per-release override that takes precedence over the project setting
- regenerate the published `nyl.toml` schema and add regression tests for parsing, precedence, and output behavior

## Testing
- cargo test --lib

Commits:
- f7539f6
- 3559a92
- d90b737