### PR TITLE
feat: add Jinja template rendering for ApplicationGenerator manifest parsing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,9 +69,9 @@ mise run docs-rustdoc     # Generate API docs
 
 ### Commit Guidelines
 
-1. **Always run `mise pre-commit` before committing**
-2. Commit at regular intervals with descriptive messages
-3. Run `cargo fmt` to format the code
+1. **Formatting and linting MUST pass before committing or creating PRs.** Run `cargo fmt` and `cargo clippy -- -D warnings` (or `mise run fmt` and `mise run lint`) and fix all issues before committing. CI will reject PRs that fail these checks.
+2. **Always run `mise pre-commit` before committing** (runs fmt-check, lint, and tests)
+3. Commit at regular intervals with descriptive messages
 4. Ensure all tests pass
 5. Update documentation if changing public APIs
 

--- a/nyl/src/cli/commands/generate.rs
+++ b/nyl/src/cli/commands/generate.rs
@@ -104,13 +104,23 @@ fn generate_argocd_applications(
     for file_path in yaml_files {
         tracing::debug!("Reading YAML file: {}", file_path.display());
 
-        // Read and parse file
+        // Read and parse file, falling back to best-effort parsing if the file
+        // contains Jinja syntax that makes it unparseable as plain YAML.
         let content = std::fs::read_to_string(&file_path)
             .map_err(|e| NylError::Config(format!("Failed to read {}: {}", file_path.display(), e)))?;
 
-        // Parse YAML documents with source context for better error messages
         let source_ctx = crate::util::SourceContext::new(file_path.clone());
-        let manifests: Vec<serde_json::Value> = source_ctx.parse_yaml_documents(&content)?;
+        let manifests: Vec<serde_json::Value> = match source_ctx.parse_yaml_documents(&content) {
+            Ok(docs) => docs,
+            Err(e) => {
+                tracing::warn!(
+                    "YAML parse error in {}: {}. Attempting best-effort document extraction.",
+                    file_path.display(),
+                    e
+                );
+                super::render::best_effort_parse_yaml_documents(&content)
+            }
+        };
 
         // Extract NylRelease metadata
         let (nyl_release, _) = extract_nyl_release(&manifests)?;

--- a/nyl/src/cli/commands/generate.rs
+++ b/nyl/src/cli/commands/generate.rs
@@ -105,7 +105,7 @@ fn generate_argocd_applications(
         tracing::debug!("Reading YAML file: {}", file_path.display());
 
         // Read and parse file, falling back to best-effort parsing if the file
-        // contains Jinja syntax that makes it unparseable as plain YAML.
+        // contains Jinja syntax or is otherwise unparseable as plain YAML.
         let content = std::fs::read_to_string(&file_path)
             .map_err(|e| NylError::Config(format!("Failed to read {}: {}", file_path.display(), e)))?;
 

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -1253,12 +1253,17 @@ fn process_application_generator(
             // Generate ArgoCD Application
             let mut app = create_argocd_application_from_generator(&release, &file_path, &source_root, generator)?;
 
-            // If rendering failed, create a "husk" application: add error info and disable auto-sync
+            // If rendering or parsing failed, create a "husk" application: add error info and disable auto-sync
             if let Some(ref error_msg) = render_error {
+                let display_path = file_path
+                    .strip_prefix(&source_root)
+                    .unwrap_or(&file_path)
+                    .display()
+                    .to_string();
                 disable_automated_sync(&mut app);
-                append_render_error_info(&mut app, &file_path, error_msg)?;
+                append_render_error_info(&mut app, &display_path, error_msg)?;
                 tracing::warn!(
-                    "Generated husk ArgoCD Application {} from NylRelease in {} (rendering failed: {})",
+                    "Generated husk ArgoCD Application {} from NylRelease in {} (rendering or parsing failed: {})",
                     release.metadata.name,
                     file_path.display(),
                     error_msg
@@ -1330,7 +1335,7 @@ fn split_yaml_documents(raw: &str) -> Vec<&str> {
 
     for line in raw.split_inclusive('\n') {
         let line_content = line.trim_end_matches(['\r', '\n']);
-        if line_content.trim() == "---" {
+        if line_content == "---" {
             if offset > start {
                 docs.push(&raw[start..offset]);
             }
@@ -1358,8 +1363,8 @@ fn disable_automated_sync(app: &mut serde_json::Value) {
     }
 }
 
-/// Add a rendering error entry to the Application's spec.info field.
-fn append_render_error_info(app: &mut serde_json::Value, file_path: &Path, error_msg: &str) -> Result<()> {
+/// Add a rendering/parsing error entry to the Application's spec.info field.
+fn append_render_error_info(app: &mut serde_json::Value, file_path: &str, error_msg: &str) -> Result<()> {
     let spec = app
         .get_mut("spec")
         .and_then(|v| v.as_object_mut())
@@ -1376,7 +1381,7 @@ fn append_render_error_info(app: &mut serde_json::Value, file_path: &Path, error
         .ok_or_else(|| NylError::Config("Application spec.info is not an array".to_string()))?;
     info_items.push(serde_json::json!({
         "name": "nyl-render-error",
-        "value": format!("Failed to render {}: {}", file_path.display(), error_msg),
+        "value": format!("Failed to render or parse {}: {}", file_path, error_msg),
     }));
     Ok(())
 }
@@ -4447,13 +4452,13 @@ data:
         let mut app = serde_json::json!({
             "spec": {}
         });
-        let file_path = Path::new("/test/file.yaml");
+        let file_path = "test/file.yaml";
         append_render_error_info(&mut app, file_path, "undefined variable 'foo'").unwrap();
         let info = app["spec"]["info"].as_array().unwrap();
         assert_eq!(info.len(), 1);
         assert_eq!(info[0]["name"], "nyl-render-error");
         assert!(info[0]["value"].as_str().unwrap().contains("undefined variable"));
-        assert!(info[0]["value"].as_str().unwrap().contains("/test/file.yaml"));
+        assert!(info[0]["value"].as_str().unwrap().contains("test/file.yaml"));
     }
 
     #[test]
@@ -4465,7 +4470,7 @@ data:
                 ]
             }
         });
-        let file_path = Path::new("/test/file.yaml");
+        let file_path = "test/file.yaml";
         append_render_error_info(&mut app, file_path, "error").unwrap();
         let info = app["spec"]["info"].as_array().unwrap();
         assert_eq!(info.len(), 2);

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -288,7 +288,7 @@ pub async fn render_manifests_complete(
 /// Shared manifest rendering logic used by render, diff, and apply
 /// Returns: (manifests, strip_empty_metadata_labels_mode, profile, env_name)
 #[allow(clippy::too_many_arguments)]
-pub async fn render_manifests(
+pub(crate) async fn render_manifests(
     path: &str,
     only_source_kind: Option<&str>,
     environment: Option<&str>,
@@ -1232,7 +1232,7 @@ fn process_application_generator(
                         file_path.display(),
                         e
                     );
-                    (best_effort_parse_yaml_documents(&raw), Some(e.to_string()))
+                    (best_effort_parse_yaml_documents(&rendered), Some(e.to_string()))
                 }
             },
             Err(e) => {
@@ -1307,7 +1307,7 @@ fn process_application_generator(
 /// document individually. Documents that fail to parse (e.g., because they contain
 /// unrendered Jinja syntax) are silently skipped. This allows extracting parseable
 /// documents (like NylRelease) even when other documents in the file are unparseable.
-pub fn best_effort_parse_yaml_documents(raw: &str) -> Vec<serde_json::Value> {
+pub(super) fn best_effort_parse_yaml_documents(raw: &str) -> Vec<serde_json::Value> {
     let mut docs = Vec::new();
     for doc_str in split_yaml_documents(raw) {
         let trimmed = doc_str.trim();
@@ -1326,26 +1326,22 @@ pub fn best_effort_parse_yaml_documents(raw: &str) -> Vec<serde_json::Value> {
 fn split_yaml_documents(raw: &str) -> Vec<&str> {
     let mut docs = Vec::new();
     let mut start = 0;
-    for line in raw.lines() {
-        if line.trim() == "---" {
-            let byte_end = raw[start..].find(line).map_or(start, |pos| start + pos);
-            if byte_end > start {
-                docs.push(&raw[start..byte_end]);
+    let mut offset = 0;
+
+    for line in raw.split_inclusive('\n') {
+        let line_content = line.trim_end_matches(['\r', '\n']);
+        if line_content.trim() == "---" {
+            if offset > start {
+                docs.push(&raw[start..offset]);
             }
-            start = byte_end + line.len();
-            // Skip the newline after "---"
-            if start < raw.len() && raw.as_bytes().get(start) == Some(&b'\n') {
-                start += 1;
-            } else if start + 1 < raw.len()
-                && raw.as_bytes().get(start) == Some(&b'\r')
-                && raw.as_bytes().get(start + 1) == Some(&b'\n')
-            {
-                start += 2;
-            }
+            start = offset + line.len();
         }
+        offset += line.len();
     }
-    if start < raw.len() {
-        let remainder = &raw[start..];
+
+    // Handle last line without trailing newline
+    if offset > start {
+        let remainder = &raw[start..offset];
         if !remainder.trim().is_empty() {
             docs.push(remainder);
         }

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -212,7 +212,7 @@ pub async fn render_manifests_complete(
     std::collections::HashMap<ResourceKey, usize>,
 )> {
     // 1. Render manifests (base pipeline)
-    let (manifests, strip_empty_metadata_labels_mode, profile, env_name, credential_provider) = render_manifests(
+    let (manifests, strip_empty_metadata_labels_mode, profile, env_name, credential_provider, template_context) = render_manifests(
         path,
         only_source_kind,
         environment,
@@ -239,7 +239,7 @@ pub async fn render_manifests_complete(
         );
     }
     for generator in generators {
-        let applications = process_application_generator(&generator, path, credential_provider.clone())?;
+        let applications = process_application_generator(&generator, path, credential_provider.clone(), &template_context)?;
         final_manifests.extend(applications);
     }
 
@@ -301,6 +301,7 @@ pub async fn render_manifests(
     Profile,
     String,
     Option<Arc<crate::git::CredentialProvider>>,
+    TemplateContext,
 )> {
     // 1. Load project configuration (with warning if not found)
     let project_config = ProjectConfig::load_with_warning(None)?;
@@ -391,6 +392,7 @@ pub async fn render_manifests(
         profile,
         profile_name,
         credential_provider,
+        context,
     ))
 }
 
@@ -1168,6 +1170,7 @@ fn process_application_generator(
     generator: &crate::resources::ApplicationGenerator,
     _base_dir: &str,
     credential_provider: Option<Arc<crate::git::CredentialProvider>>,
+    template_context: &TemplateContext,
 ) -> Result<Vec<serde_json::Value>> {
     let source_selectors = application_generator_source_selectors(generator);
     tracing::debug!(
@@ -1199,6 +1202,9 @@ fn process_application_generator(
     );
     let scanned_file_count = yaml_files.len();
 
+    let engine = TemplateEngine::new();
+    let ctx_json = template_context.to_json();
+
     let mut applications = Vec::new();
     let mut missing_release_files = Vec::new();
     let mut missing_release_count = 0usize;
@@ -1206,23 +1212,63 @@ fn process_application_generator(
     for file_path in yaml_files {
         tracing::debug!("Reading YAML file: {}", file_path.display());
 
-        // Read and parse file
-        let content = std::fs::read_to_string(&file_path)
+        // Read file
+        let raw = std::fs::read_to_string(&file_path)
             .map_err(|e| NylError::Config(format!("Failed to read file {}: {}", file_path.display(), e)))?;
         let source_ctx = crate::util::SourceContext::new(file_path.clone());
-        let docs = source_ctx.parse_yaml_documents(&content)?;
+
+        // Try Jinja rendering, then parse YAML. On failure, fall back to best-effort parsing
+        // of individual YAML documents so we can still extract NylRelease metadata (which
+        // typically doesn't use Jinja) even when other documents in the file do.
+        let (docs, render_error) =
+            match engine.render_named(&file_path.display().to_string(), &raw, &ctx_json) {
+                Ok(rendered) => match source_ctx.parse_yaml_documents(&rendered) {
+                    Ok(docs) => (docs, None),
+                    Err(e) => {
+                        tracing::warn!(
+                            "YAML parse error after Jinja rendering in {}: {}. \
+                             Attempting best-effort document extraction.",
+                            file_path.display(),
+                            e
+                        );
+                        (best_effort_parse_yaml_documents(&raw), Some(e.to_string()))
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!(
+                        "Jinja template rendering failed for {}: {}. \
+                         Attempting best-effort document extraction.",
+                        file_path.display(),
+                        e
+                    );
+                    (best_effort_parse_yaml_documents(&raw), Some(e.to_string()))
+                }
+            };
 
         // Extract NylRelease
         let (nyl_release, _) = extract_nyl_release(&docs)?;
 
         if let Some(release) = nyl_release {
             // Generate ArgoCD Application
-            let app = create_argocd_application_from_generator(&release, &file_path, &source_root, generator)?;
-            tracing::debug!(
-                "Generated ArgoCD Application {} from NylRelease in {}",
-                release.metadata.name,
-                file_path.display()
-            );
+            let mut app = create_argocd_application_from_generator(&release, &file_path, &source_root, generator)?;
+
+            // If rendering failed, create a "husk" application: add error info and disable auto-sync
+            if let Some(ref error_msg) = render_error {
+                disable_automated_sync(&mut app);
+                append_render_error_info(&mut app, &file_path, error_msg)?;
+                tracing::warn!(
+                    "Generated husk ArgoCD Application {} from NylRelease in {} (rendering failed: {})",
+                    release.metadata.name,
+                    file_path.display(),
+                    error_msg
+                );
+            } else {
+                tracing::debug!(
+                    "Generated ArgoCD Application {} from NylRelease in {}",
+                    release.metadata.name,
+                    file_path.display()
+                );
+            }
             applications.push(app);
         } else {
             tracing::trace!("No NylRelease found in {}, skipping", file_path.display());
@@ -1252,6 +1298,94 @@ fn process_application_generator(
         applications.len()
     );
     Ok(applications)
+}
+
+/// Parse a multi-document YAML string on a best-effort basis.
+///
+/// Splits the input on YAML document separators (`---`) and tries to parse each
+/// document individually. Documents that fail to parse (e.g., because they contain
+/// unrendered Jinja syntax) are silently skipped. This allows extracting parseable
+/// documents (like NylRelease) even when other documents in the file are unparseable.
+pub fn best_effort_parse_yaml_documents(raw: &str) -> Vec<serde_json::Value> {
+    let mut docs = Vec::new();
+    for doc_str in split_yaml_documents(raw) {
+        let trimmed = doc_str.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match crate::yaml::parse_yaml_documents_k8s_compatible(trimmed) {
+            Ok(parsed) => docs.extend(parsed),
+            Err(_) => continue,
+        }
+    }
+    docs
+}
+
+/// Split a YAML string into individual document strings by `---` separators.
+fn split_yaml_documents(raw: &str) -> Vec<&str> {
+    let mut docs = Vec::new();
+    let mut start = 0;
+    for (i, line) in raw.lines().enumerate() {
+        if line.trim() == "---" {
+            let byte_end = raw[start..]
+                .find(line)
+                .map(|pos| start + pos)
+                .unwrap_or(start);
+            if byte_end > start {
+                docs.push(&raw[start..byte_end]);
+            }
+            start = byte_end + line.len();
+            // Skip the newline after "---"
+            if start < raw.len() && raw.as_bytes().get(start) == Some(&b'\n') {
+                start += 1;
+            } else if start + 1 < raw.len()
+                && raw.as_bytes().get(start) == Some(&b'\r')
+                && raw.as_bytes().get(start + 1) == Some(&b'\n')
+            {
+                start += 2;
+            }
+        }
+        let _ = i;
+    }
+    if start < raw.len() {
+        let remainder = &raw[start..];
+        if !remainder.trim().is_empty() {
+            docs.push(remainder);
+        }
+    }
+    docs
+}
+
+/// Remove automated sync policy from an ArgoCD Application manifest.
+fn disable_automated_sync(app: &mut serde_json::Value) {
+    if let Some(spec) = app.get_mut("spec").and_then(|v| v.as_object_mut()) {
+        if let Some(sync_policy) = spec.get_mut("syncPolicy").and_then(|v| v.as_object_mut()) {
+            sync_policy.remove("automated");
+        }
+    }
+}
+
+/// Add a rendering error entry to the Application's spec.info field.
+fn append_render_error_info(app: &mut serde_json::Value, file_path: &Path, error_msg: &str) -> Result<()> {
+    let spec = app
+        .get_mut("spec")
+        .and_then(|v| v.as_object_mut())
+        .ok_or_else(|| NylError::Config("Generated Application is missing spec".to_string()))?;
+    let info_value = spec
+        .entry("info".to_string())
+        .or_insert_with(|| serde_json::Value::Array(Vec::new()));
+    if !info_value.is_array() {
+        let previous = std::mem::take(info_value);
+        *info_value = serde_json::Value::Array(vec![previous]);
+    }
+    let info_items = info_value
+        .as_array_mut()
+        .ok_or_else(|| NylError::Config("Application spec.info is not an array".to_string()))?;
+    info_items.push(serde_json::json!({
+        "name": "nyl-render-error",
+        "value": format!("Failed to render {}: {}", file_path.display(), error_msg),
+    }));
+    Ok(())
 }
 
 fn missing_nyl_release_warning_message(
@@ -4223,5 +4357,126 @@ metadata:
             &[],
             true
         ));
+    }
+
+    #[test]
+    fn test_split_yaml_documents_single() {
+        let raw = "apiVersion: v1\nkind: ConfigMap\n";
+        let docs = split_yaml_documents(raw);
+        assert_eq!(docs.len(), 1);
+        assert!(docs[0].contains("ConfigMap"));
+    }
+
+    #[test]
+    fn test_split_yaml_documents_multiple() {
+        let raw = "apiVersion: v1\nkind: ConfigMap\n---\napiVersion: v1\nkind: Service\n";
+        let docs = split_yaml_documents(raw);
+        assert_eq!(docs.len(), 2);
+        assert!(docs[0].contains("ConfigMap"));
+        assert!(docs[1].contains("Service"));
+    }
+
+    #[test]
+    fn test_split_yaml_documents_leading_separator() {
+        let raw = "---\napiVersion: v1\nkind: ConfigMap\n";
+        let docs = split_yaml_documents(raw);
+        assert_eq!(docs.len(), 1);
+        assert!(docs[0].contains("ConfigMap"));
+    }
+
+    #[test]
+    fn test_best_effort_parse_yaml_documents_valid() {
+        let raw = "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: test\n";
+        let docs = best_effort_parse_yaml_documents(raw);
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0]["kind"], "ConfigMap");
+    }
+
+    #[test]
+    fn test_best_effort_parse_yaml_documents_skips_jinja() {
+        let raw = r#"apiVersion: nyl.niklasrosenstein.github.com/v1
+kind: NylRelease
+metadata:
+  name: my-app
+  namespace: default
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ values.config_name }}
+data:
+  key: {{ values.some_value }}
+"#;
+        let docs = best_effort_parse_yaml_documents(raw);
+        // The NylRelease should parse, the ConfigMap with Jinja should be skipped
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0]["kind"], "NylRelease");
+        assert_eq!(docs[0]["metadata"]["name"], "my-app");
+    }
+
+    #[test]
+    fn test_best_effort_parse_yaml_documents_all_invalid() {
+        let raw = "key: {{ values.foo }}\n---\nother: {{ values.bar }}\n";
+        let docs = best_effort_parse_yaml_documents(raw);
+        assert!(docs.is_empty());
+    }
+
+    #[test]
+    fn test_disable_automated_sync() {
+        let mut app = serde_json::json!({
+            "spec": {
+                "syncPolicy": {
+                    "automated": {
+                        "prune": true,
+                        "selfHeal": true
+                    },
+                    "syncOptions": ["CreateNamespace=true"]
+                }
+            }
+        });
+        disable_automated_sync(&mut app);
+        assert!(app["spec"]["syncPolicy"]["automated"].is_null());
+        assert_eq!(app["spec"]["syncPolicy"]["syncOptions"][0], "CreateNamespace=true");
+    }
+
+    #[test]
+    fn test_disable_automated_sync_no_sync_policy() {
+        let mut app = serde_json::json!({
+            "spec": {}
+        });
+        disable_automated_sync(&mut app);
+        // Should not panic or error
+        assert!(app["spec"]["syncPolicy"].is_null());
+    }
+
+    #[test]
+    fn test_append_render_error_info() {
+        let mut app = serde_json::json!({
+            "spec": {}
+        });
+        let file_path = Path::new("/test/file.yaml");
+        append_render_error_info(&mut app, file_path, "undefined variable 'foo'").unwrap();
+        let info = app["spec"]["info"].as_array().unwrap();
+        assert_eq!(info.len(), 1);
+        assert_eq!(info[0]["name"], "nyl-render-error");
+        assert!(info[0]["value"].as_str().unwrap().contains("undefined variable"));
+        assert!(info[0]["value"].as_str().unwrap().contains("/test/file.yaml"));
+    }
+
+    #[test]
+    fn test_append_render_error_info_preserves_existing() {
+        let mut app = serde_json::json!({
+            "spec": {
+                "info": [
+                    {"name": "existing", "value": "entry"}
+                ]
+            }
+        });
+        let file_path = Path::new("/test/file.yaml");
+        append_render_error_info(&mut app, file_path, "error").unwrap();
+        let info = app["spec"]["info"].as_array().unwrap();
+        assert_eq!(info.len(), 2);
+        assert_eq!(info[0]["name"], "existing");
+        assert_eq!(info[1]["name"], "nyl-render-error");
     }
 }

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -286,7 +286,7 @@ pub async fn render_manifests_complete(
 }
 
 /// Shared manifest rendering logic used by render, diff, and apply
-/// Returns: (manifests, strip_empty_metadata_labels_mode, profile, env_name)
+/// Returns: (manifests, strip_empty_metadata_labels_mode, profile, env_name, credential_provider, template_context)
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn render_manifests(
     path: &str,
@@ -1218,11 +1218,16 @@ fn process_application_generator(
         let raw = std::fs::read_to_string(&file_path)
             .map_err(|e| NylError::Config(format!("Failed to read file {}: {}", file_path.display(), e)))?;
         let source_ctx = crate::util::SourceContext::new(file_path.clone());
+        let rel_path = file_path
+            .strip_prefix(&source_root)
+            .unwrap_or(&file_path)
+            .display()
+            .to_string();
 
         // Try Jinja rendering, then parse YAML. On failure, fall back to best-effort parsing
         // of individual YAML documents so we can still extract NylRelease metadata (which
         // typically doesn't use Jinja) even when other documents in the file do.
-        let (docs, render_error) = match engine.render_named(&file_path.display().to_string(), &raw, &ctx_json) {
+        let (docs, render_error) = match engine.render_named(&rel_path, &raw, &ctx_json) {
             Ok(rendered) => match source_ctx.parse_yaml_documents(&rendered) {
                 Ok(docs) => (docs, None),
                 Err(e) => {
@@ -1255,13 +1260,8 @@ fn process_application_generator(
 
             // If rendering or parsing failed, create a "husk" application: add error info and disable auto-sync
             if let Some(ref error_msg) = render_error {
-                let display_path = file_path
-                    .strip_prefix(&source_root)
-                    .unwrap_or(&file_path)
-                    .display()
-                    .to_string();
                 disable_automated_sync(&mut app);
-                append_render_error_info(&mut app, &display_path, error_msg)?;
+                append_render_error_info(&mut app, &rel_path, error_msg)?;
                 tracing::warn!(
                     "Generated husk ArgoCD Application {} from NylRelease in {} (rendering or parsing failed: {})",
                     release.metadata.name,

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -212,17 +212,18 @@ pub async fn render_manifests_complete(
     std::collections::HashMap<ResourceKey, usize>,
 )> {
     // 1. Render manifests (base pipeline)
-    let (manifests, strip_empty_metadata_labels_mode, profile, env_name, credential_provider, template_context) = render_manifests(
-        path,
-        only_source_kind,
-        environment,
-        offline,
-        cli_kube_version,
-        cli_api_versions,
-        max_depth,
-        track_parent,
-    )
-    .await?;
+    let (manifests, strip_empty_metadata_labels_mode, profile, env_name, credential_provider, template_context) =
+        render_manifests(
+            path,
+            only_source_kind,
+            environment,
+            offline,
+            cli_kube_version,
+            cli_api_versions,
+            max_depth,
+            track_parent,
+        )
+        .await?;
 
     // 2. Extract NylRelease metadata (before filtering it out)
     let (nyl_release, manifests) = extract_nyl_release(&manifests)?;
@@ -239,7 +240,8 @@ pub async fn render_manifests_complete(
         );
     }
     for generator in generators {
-        let applications = process_application_generator(&generator, path, credential_provider.clone(), &template_context)?;
+        let applications =
+            process_application_generator(&generator, path, credential_provider.clone(), &template_context)?;
         final_manifests.extend(applications);
     }
 
@@ -1220,30 +1222,29 @@ fn process_application_generator(
         // Try Jinja rendering, then parse YAML. On failure, fall back to best-effort parsing
         // of individual YAML documents so we can still extract NylRelease metadata (which
         // typically doesn't use Jinja) even when other documents in the file do.
-        let (docs, render_error) =
-            match engine.render_named(&file_path.display().to_string(), &raw, &ctx_json) {
-                Ok(rendered) => match source_ctx.parse_yaml_documents(&rendered) {
-                    Ok(docs) => (docs, None),
-                    Err(e) => {
-                        tracing::warn!(
-                            "YAML parse error after Jinja rendering in {}: {}. \
-                             Attempting best-effort document extraction.",
-                            file_path.display(),
-                            e
-                        );
-                        (best_effort_parse_yaml_documents(&raw), Some(e.to_string()))
-                    }
-                },
+        let (docs, render_error) = match engine.render_named(&file_path.display().to_string(), &raw, &ctx_json) {
+            Ok(rendered) => match source_ctx.parse_yaml_documents(&rendered) {
+                Ok(docs) => (docs, None),
                 Err(e) => {
                     tracing::warn!(
-                        "Jinja template rendering failed for {}: {}. \
-                         Attempting best-effort document extraction.",
+                        "YAML parse error after Jinja rendering in {}: {}. \
+                             Attempting best-effort document extraction.",
                         file_path.display(),
                         e
                     );
                     (best_effort_parse_yaml_documents(&raw), Some(e.to_string()))
                 }
-            };
+            },
+            Err(e) => {
+                tracing::warn!(
+                    "Jinja template rendering failed for {}: {}. \
+                         Attempting best-effort document extraction.",
+                    file_path.display(),
+                    e
+                );
+                (best_effort_parse_yaml_documents(&raw), Some(e.to_string()))
+            }
+        };
 
         // Extract NylRelease
         let (nyl_release, _) = extract_nyl_release(&docs)?;
@@ -1315,7 +1316,7 @@ pub fn best_effort_parse_yaml_documents(raw: &str) -> Vec<serde_json::Value> {
         }
         match crate::yaml::parse_yaml_documents_k8s_compatible(trimmed) {
             Ok(parsed) => docs.extend(parsed),
-            Err(_) => continue,
+            Err(_) => {}
         }
     }
     docs
@@ -1325,12 +1326,9 @@ pub fn best_effort_parse_yaml_documents(raw: &str) -> Vec<serde_json::Value> {
 fn split_yaml_documents(raw: &str) -> Vec<&str> {
     let mut docs = Vec::new();
     let mut start = 0;
-    for (i, line) in raw.lines().enumerate() {
+    for line in raw.lines() {
         if line.trim() == "---" {
-            let byte_end = raw[start..]
-                .find(line)
-                .map(|pos| start + pos)
-                .unwrap_or(start);
+            let byte_end = raw[start..].find(line).map_or(start, |pos| start + pos);
             if byte_end > start {
                 docs.push(&raw[start..byte_end]);
             }
@@ -1345,7 +1343,6 @@ fn split_yaml_documents(raw: &str) -> Vec<&str> {
                 start += 2;
             }
         }
-        let _ = i;
     }
     if start < raw.len() {
         let remainder = &raw[start..];

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -1168,6 +1168,48 @@ fn output_manifests(
 }
 
 /// Process ApplicationGenerator - scan directory and generate Applications
+/// Read a YAML file, render it with Jinja, and parse the result.
+/// Falls back to best-effort document extraction on render or parse failure.
+fn render_yaml_file_with_jinja(
+    file_path: &Path,
+    source_root: &Path,
+    engine: &TemplateEngine,
+    ctx_json: &serde_json::Value,
+) -> Result<(Vec<serde_json::Value>, Option<String>)> {
+    let raw = std::fs::read_to_string(file_path)
+        .map_err(|e| NylError::Config(format!("Failed to read file {}: {}", file_path.display(), e)))?;
+    let source_ctx = crate::util::SourceContext::new(file_path.to_path_buf());
+    let rel_path = file_path
+        .strip_prefix(source_root)
+        .unwrap_or(file_path)
+        .display()
+        .to_string();
+
+    Ok(match engine.render_named(&rel_path, &raw, ctx_json) {
+        Ok(rendered) => match source_ctx.parse_yaml_documents(&rendered) {
+            Ok(docs) => (docs, None),
+            Err(e) => {
+                tracing::warn!(
+                    "YAML parse error after Jinja rendering in {}: {}. \
+                         Attempting best-effort document extraction.",
+                    file_path.display(),
+                    e
+                );
+                (best_effort_parse_yaml_documents(&rendered), Some(e.to_string()))
+            }
+        },
+        Err(e) => {
+            tracing::warn!(
+                "Jinja template rendering failed for {}: {}. \
+                     Attempting best-effort document extraction.",
+                file_path.display(),
+                e
+            );
+            (best_effort_parse_yaml_documents(&raw), Some(e.to_string()))
+        }
+    })
+}
+
 fn process_application_generator(
     generator: &crate::resources::ApplicationGenerator,
     _base_dir: &str,
@@ -1214,42 +1256,7 @@ fn process_application_generator(
     for file_path in yaml_files {
         tracing::debug!("Reading YAML file: {}", file_path.display());
 
-        // Read file
-        let raw = std::fs::read_to_string(&file_path)
-            .map_err(|e| NylError::Config(format!("Failed to read file {}: {}", file_path.display(), e)))?;
-        let source_ctx = crate::util::SourceContext::new(file_path.clone());
-        let rel_path = file_path
-            .strip_prefix(&source_root)
-            .unwrap_or(&file_path)
-            .display()
-            .to_string();
-
-        // Try Jinja rendering, then parse YAML. On failure, fall back to best-effort parsing
-        // of individual YAML documents so we can still extract NylRelease metadata (which
-        // typically doesn't use Jinja) even when other documents in the file do.
-        let (docs, render_error) = match engine.render_named(&rel_path, &raw, &ctx_json) {
-            Ok(rendered) => match source_ctx.parse_yaml_documents(&rendered) {
-                Ok(docs) => (docs, None),
-                Err(e) => {
-                    tracing::warn!(
-                        "YAML parse error after Jinja rendering in {}: {}. \
-                             Attempting best-effort document extraction.",
-                        file_path.display(),
-                        e
-                    );
-                    (best_effort_parse_yaml_documents(&rendered), Some(e.to_string()))
-                }
-            },
-            Err(e) => {
-                tracing::warn!(
-                    "Jinja template rendering failed for {}: {}. \
-                         Attempting best-effort document extraction.",
-                    file_path.display(),
-                    e
-                );
-                (best_effort_parse_yaml_documents(&raw), Some(e.to_string()))
-            }
-        };
+        let (docs, render_error) = render_yaml_file_with_jinja(&file_path, &source_root, &engine, &ctx_json)?;
 
         // Extract NylRelease
         let (nyl_release, _) = extract_nyl_release(&docs)?;
@@ -1260,6 +1267,11 @@ fn process_application_generator(
 
             // If rendering or parsing failed, create a "husk" application: add error info and disable auto-sync
             if let Some(ref error_msg) = render_error {
+                let rel_path = file_path
+                    .strip_prefix(&source_root)
+                    .unwrap_or(&file_path)
+                    .display()
+                    .to_string();
                 disable_automated_sync(&mut app);
                 append_render_error_info(&mut app, &rel_path, error_msg)?;
                 tracing::warn!(
@@ -1319,9 +1331,8 @@ pub(super) fn best_effort_parse_yaml_documents(raw: &str) -> Vec<serde_json::Val
         if trimmed.is_empty() {
             continue;
         }
-        match crate::yaml::parse_yaml_documents_k8s_compatible(trimmed) {
-            Ok(parsed) => docs.extend(parsed),
-            Err(_) => {}
+        if let Ok(parsed) = crate::yaml::parse_yaml_documents_k8s_compatible(trimmed) {
+            docs.extend(parsed);
         }
     }
     docs
@@ -4392,7 +4403,7 @@ metadata:
 
     #[test]
     fn test_best_effort_parse_yaml_documents_skips_jinja() {
-        let raw = r#"apiVersion: nyl.niklasrosenstein.github.com/v1
+        let raw = r"apiVersion: nyl.niklasrosenstein.github.com/v1
 kind: NylRelease
 metadata:
   name: my-app
@@ -4404,7 +4415,7 @@ metadata:
   name: {{ values.config_name }}
 data:
   key: {{ values.some_value }}
-"#;
+";
         let docs = best_effort_parse_yaml_documents(raw);
         // The NylRelease should parse, the ConfigMap with Jinja should be skipped
         assert_eq!(docs.len(), 1);


### PR DESCRIPTION
## Summary
- Adds Jinja template rendering to `process_application_generator` before YAML parsing, matching the behavior of `load_resources`
- When Jinja rendering or YAML parsing fails, falls back to best-effort per-document parsing so NylRelease metadata (which typically doesn't use Jinja) can still be extracted
- Creates "husk" ArgoCD Applications for files with render errors: error details in `spec.info`, automated sync disabled
- Also adds best-effort YAML parsing fallback to `generate_argocd_applications` in generate.rs

## Test plan
- [x] Unit tests for `best_effort_parse_yaml_documents` (valid YAML, mixed Jinja/valid, all invalid)
- [x] Unit tests for `split_yaml_documents` (single, multiple, leading separator)
- [x] Unit tests for `disable_automated_sync` (with/without sync policy)
- [x] Unit tests for `append_render_error_info` (empty info, preserves existing entries)
- [x] All existing tests pass
- [x] Manual test: create a YAML file with Jinja syntax alongside a NylRelease and run `nyl render` with an ApplicationGenerator pointing to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)