### PR TITLE
fix(diff): handle unknown CRD resources gracefully with annotated output

### DIFF
--- a/.github/workflows/_build-rust.yaml
+++ b/.github/workflows/_build-rust.yaml
@@ -50,6 +50,9 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Add cross-compilation target to active toolchain
+        run: rustup target add ${{ matrix.target }}
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/_build-rust.yaml
+++ b/.github/workflows/_build-rust.yaml
@@ -46,12 +46,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: ${{ matrix.target }}
-
-      - name: Add cross-compilation target to active toolchain
-        run: rustup target add ${{ matrix.target }}
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Authenticate with crates.io (trusted publishing)
         uses: rust-lang/crates-io-auth-action@v1
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
 
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2562,9 +2562,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 # Rust toolchain (PRIMARY)
-rust = "1.94.1"
+rust = "1.95.0"
 
 # Cargo extensions for development and release
 "cargo:cargo-dist" = "latest"

--- a/nyl/src/cli/commands/diff.rs
+++ b/nyl/src/cli/commands/diff.rs
@@ -799,7 +799,7 @@ mod tests {
         async fn is_namespaced(&self, _gvk: &GroupVersionKind) -> Result<bool> {
             Ok(true)
         }
-        fn default_namespace(&self) -> &str {
+        fn default_namespace(&self) -> &'static str {
             "default"
         }
         async fn delete_resource(&self, _gvk: &GroupVersionKind, _namespace: Option<&str>, _name: &str) -> Result<()> {

--- a/nyl/src/cli/commands/diff.rs
+++ b/nyl/src/cli/commands/diff.rs
@@ -233,6 +233,7 @@ impl DiffResult {
 }
 
 /// Compute diff between desired manifests and LIVE cluster state
+#[allow(clippy::too_many_lines)]
 async fn compute_diff_from_live(
     client: &dyn KubeClient,
     desired_manifests: &[serde_json::Value],
@@ -413,7 +414,7 @@ fn display_diff(diff: &DiffResult, duplicates: &HashMap<ResourceKey, usize>) {
     // Show added resources
     for (key, note) in &diff.added {
         let dup_annotation = get_duplicate_annotation_for_key(key, duplicates);
-        let note_annotation = format_added_note(note);
+        let note_annotation = format_added_note(note.as_ref());
         println!("{} {}{}{}", "+".green().bold(), key, dup_annotation, note_annotation);
     }
     if !diff.added.is_empty() {
@@ -471,7 +472,7 @@ fn display_diff(diff: &DiffResult, duplicates: &HashMap<ResourceKey, usize>) {
 fn display_summary(diff: &DiffResult, duplicates: &HashMap<ResourceKey, usize>) {
     for (key, note) in &diff.added {
         let dup_annotation = get_duplicate_annotation_for_key(key, duplicates);
-        let note_annotation = format_added_note(note);
+        let note_annotation = format_added_note(note.as_ref());
         println!("{} {}{}{}", "+".green().bold(), key, dup_annotation, note_annotation);
     }
 
@@ -513,7 +514,7 @@ fn print_duplicate_warning(duplicates: &HashMap<ResourceKey, usize>) {
     );
 }
 
-fn format_added_note(note: &Option<AddedNote>) -> String {
+fn format_added_note(note: Option<&AddedNote>) -> String {
     match note {
         Some(n) if n.is_error => format!(" {}", format!("({})", n.message).red()),
         Some(n) => format!(" {}", format!("({})", n.message).yellow()),

--- a/nyl/src/cli/commands/diff.rs
+++ b/nyl/src/cli/commands/diff.rs
@@ -284,6 +284,9 @@ async fn compute_diff_from_live(
         }
     }
 
+    // Precompute the set of CRD (group, kind, version) tuples present in desired_manifests.
+    let crd_set = build_crd_version_set(desired_manifests);
+
     // Categorize changes
     let mut added = Vec::new();
     let mut modified = Vec::new();
@@ -343,7 +346,7 @@ async fn compute_diff_from_live(
             }
         } else {
             let note = if crd_not_found_keys.contains(&key) {
-                if crd_in_manifests(&key.gvk, desired_manifests) {
+                if crd_in_manifests(&key.gvk, &crd_set) {
                     Some(AddedNote {
                         message: "CRD will be installed".to_string(),
                         is_error: false,
@@ -532,27 +535,61 @@ fn get_duplicate_annotation_for_key(key: &ResourceKey, duplicates: &HashMap<Reso
     String::new()
 }
 
-fn crd_in_manifests(gvk: &GroupVersionKind, manifests: &[serde_json::Value]) -> bool {
-    manifests.iter().any(|m| {
+/// Build a set of (group, kind, version) tuples from CRDs present in the manifests.
+/// For v1 CRDs only versions with `served: true` are included.
+/// For v1beta1 CRDs both `spec.version` (single) and `spec.versions[]` are checked.
+fn build_crd_version_set(manifests: &[serde_json::Value]) -> HashSet<(String, String, String)> {
+    let mut set = HashSet::new();
+    for m in manifests {
         let api_version = m.get("apiVersion").and_then(|v| v.as_str()).unwrap_or("");
         let kind = m.get("kind").and_then(|v| v.as_str()).unwrap_or("");
         if kind != "CustomResourceDefinition"
             || (api_version != "apiextensions.k8s.io/v1" && api_version != "apiextensions.k8s.io/v1beta1")
         {
-            return false;
+            continue;
         }
         let spec = m.get("spec");
-        let group_matches = spec
-            .and_then(|s| s.get("group"))
-            .and_then(|g| g.as_str())
-            .is_some_and(|g| g == gvk.group);
-        let kind_matches = spec
+        let Some(group) = spec.and_then(|s| s.get("group")).and_then(|g| g.as_str()) else {
+            continue;
+        };
+        let Some(crd_kind) = spec
             .and_then(|s| s.get("names"))
             .and_then(|n| n.get("kind"))
             .and_then(|k| k.as_str())
-            .is_some_and(|k| k == gvk.kind);
-        group_matches && kind_matches
-    })
+        else {
+            continue;
+        };
+        if api_version == "apiextensions.k8s.io/v1" {
+            if let Some(versions) = spec.and_then(|s| s.get("versions")).and_then(|v| v.as_array()) {
+                for ver in versions {
+                    let served = ver.get("served").and_then(|s| s.as_bool()).unwrap_or(false);
+                    if !served {
+                        continue;
+                    }
+                    if let Some(ver_name) = ver.get("name").and_then(|v| v.as_str()) {
+                        set.insert((group.to_string(), crd_kind.to_string(), ver_name.to_string()));
+                    }
+                }
+            }
+        } else {
+            // v1beta1: spec.version (single string) or spec.versions (array)
+            if let Some(ver) = spec.and_then(|s| s.get("version")).and_then(|v| v.as_str()) {
+                set.insert((group.to_string(), crd_kind.to_string(), ver.to_string()));
+            }
+            if let Some(versions) = spec.and_then(|s| s.get("versions")).and_then(|v| v.as_array()) {
+                for ver_entry in versions {
+                    if let Some(ver_name) = ver_entry.get("name").and_then(|v| v.as_str()) {
+                        set.insert((group.to_string(), crd_kind.to_string(), ver_name.to_string()));
+                    }
+                }
+            }
+        }
+    }
+    set
+}
+
+fn crd_in_manifests(gvk: &GroupVersionKind, crd_set: &HashSet<(String, String, String)>) -> bool {
+    crd_set.contains(&(gvk.group.clone(), gvk.kind.clone(), gvk.version.clone()))
 }
 
 fn missing_release_warning_message(namespace: &str, release_name: &str) -> String {
@@ -619,12 +656,248 @@ async fn merge_with_previous_release(
 
 #[cfg(test)]
 mod tests {
-    use super::missing_release_warning_message;
+    use super::*;
+    use crate::kubernetes::ApplyOutcome;
+    use async_trait::async_trait;
+    use kube::api::DynamicObject;
+    use serde_json::json;
 
     #[test]
     fn test_missing_release_warning_message_mentions_prune_limitation() {
         let msg = missing_release_warning_message("default", "demo");
         assert!(msg.contains("default/demo"));
         assert!(msg.contains("prune candidates cannot be determined"));
+    }
+
+    #[test]
+    fn test_build_crd_version_set_v1_served_only() {
+        let manifests = vec![json!({
+            "apiVersion": "apiextensions.k8s.io/v1",
+            "kind": "CustomResourceDefinition",
+            "spec": {
+                "group": "example.com",
+                "names": { "kind": "MyResource" },
+                "versions": [
+                    { "name": "v1", "served": true, "storage": true },
+                    { "name": "v1beta1", "served": false, "storage": false }
+                ]
+            }
+        })];
+        let set = build_crd_version_set(&manifests);
+        assert!(set.contains(&("example.com".to_string(), "MyResource".to_string(), "v1".to_string())));
+        assert!(!set.contains(&(
+            "example.com".to_string(),
+            "MyResource".to_string(),
+            "v1beta1".to_string()
+        )));
+    }
+
+    #[test]
+    fn test_build_crd_version_set_v1beta1_single_version() {
+        let manifests = vec![json!({
+            "apiVersion": "apiextensions.k8s.io/v1beta1",
+            "kind": "CustomResourceDefinition",
+            "spec": {
+                "group": "example.com",
+                "names": { "kind": "MyResource" },
+                "version": "v1alpha1"
+            }
+        })];
+        let set = build_crd_version_set(&manifests);
+        assert!(set.contains(&(
+            "example.com".to_string(),
+            "MyResource".to_string(),
+            "v1alpha1".to_string()
+        )));
+    }
+
+    #[test]
+    fn test_crd_in_manifests_matches_group_kind_and_version() {
+        let manifests = vec![json!({
+            "apiVersion": "apiextensions.k8s.io/v1",
+            "kind": "CustomResourceDefinition",
+            "spec": {
+                "group": "example.com",
+                "names": { "kind": "MyResource" },
+                "versions": [{ "name": "v1", "served": true, "storage": true }]
+            }
+        })];
+        let set = build_crd_version_set(&manifests);
+
+        let matching_gvk = GroupVersionKind {
+            group: "example.com".to_string(),
+            version: "v1".to_string(),
+            kind: "MyResource".to_string(),
+        };
+        assert!(crd_in_manifests(&matching_gvk, &set));
+
+        let wrong_version = GroupVersionKind {
+            group: "example.com".to_string(),
+            version: "v2".to_string(),
+            kind: "MyResource".to_string(),
+        };
+        assert!(!crd_in_manifests(&wrong_version, &set));
+
+        let wrong_group = GroupVersionKind {
+            group: "other.io".to_string(),
+            version: "v1".to_string(),
+            kind: "MyResource".to_string(),
+        };
+        assert!(!crd_in_manifests(&wrong_group, &set));
+    }
+
+    /// A KubeClient that returns ApiResourceNotFound for a specific set of GVKs and Ok(None) for all others.
+    struct SelectiveApiResourceNotFoundClient {
+        error_gvks: HashSet<(String, String, String)>,
+    }
+
+    impl SelectiveApiResourceNotFoundClient {
+        fn new(error_gvks: impl IntoIterator<Item = (&'static str, &'static str, &'static str)>) -> Self {
+            Self {
+                error_gvks: error_gvks
+                    .into_iter()
+                    .map(|(g, v, k)| (g.to_string(), v.to_string(), k.to_string()))
+                    .collect(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl KubeClient for SelectiveApiResourceNotFoundClient {
+        async fn get_resource(
+            &self,
+            gvk: &GroupVersionKind,
+            _namespace: Option<&str>,
+            _name: &str,
+        ) -> Result<Option<DynamicObject>> {
+            if self
+                .error_gvks
+                .contains(&(gvk.group.clone(), gvk.version.clone(), gvk.kind.clone()))
+            {
+                Err(NylError::ApiResourceNotFound(format!(
+                    "{}/{}/{}",
+                    gvk.group, gvk.version, gvk.kind
+                )))
+            } else {
+                Ok(None)
+            }
+        }
+        async fn apply_resource(
+            &self,
+            _resource: &DynamicObject,
+            _field_manager: &str,
+            _dry_run: bool,
+        ) -> Result<ApplyOutcome> {
+            Err(NylError::Other("not used".to_string()))
+        }
+        async fn get_server_version(&self) -> Result<String> {
+            Ok("1.30.0".to_string())
+        }
+        async fn get_api_versions(&self) -> Result<Vec<String>> {
+            Ok(vec![])
+        }
+        async fn is_namespaced(&self, _gvk: &GroupVersionKind) -> Result<bool> {
+            Ok(true)
+        }
+        fn default_namespace(&self) -> &str {
+            "default"
+        }
+        async fn delete_resource(&self, _gvk: &GroupVersionKind, _namespace: Option<&str>, _name: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn get_normalized_resource(
+            &self,
+            resource: &DynamicObject,
+            _field_manager: &str,
+        ) -> Result<DynamicObject> {
+            Ok(resource.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_diff_api_resource_not_found_crd_will_be_installed() {
+        let crd = json!({
+            "apiVersion": "apiextensions.k8s.io/v1",
+            "kind": "CustomResourceDefinition",
+            "metadata": { "name": "mypolicies.kyverno.io" },
+            "spec": {
+                "group": "kyverno.io",
+                "names": { "kind": "ClusterPolicy", "plural": "clusterpolicies" },
+                "versions": [{ "name": "v1", "served": true, "storage": true }],
+                "scope": "Cluster"
+            }
+        });
+        let cr = json!({
+            "apiVersion": "kyverno.io/v1",
+            "kind": "ClusterPolicy",
+            "metadata": { "name": "my-policy" }
+        });
+        let manifests = vec![crd, cr];
+        // Only the CR's GVK is unknown; the CRD manifest type is always available.
+        let client = SelectiveApiResourceNotFoundClient::new([("kyverno.io", "v1", "ClusterPolicy")]);
+        let result = compute_diff_from_live(&client, &manifests, None, DiffMode::Raw)
+            .await
+            .unwrap();
+
+        // The CR should be in `added` with a non-error note ("CRD will be installed")
+        let cr_entry = result.added.iter().find(|(k, _)| k.gvk.kind == "ClusterPolicy");
+        assert!(cr_entry.is_some(), "ClusterPolicy should appear in added");
+        let note = cr_entry.unwrap().1.as_ref().expect("should have a note");
+        assert!(!note.is_error, "note should not be an error when CRD is in manifests");
+        assert!(note.message.contains("CRD will be installed"));
+        assert_eq!(result.total_error_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_diff_api_resource_not_found_crd_not_installed() {
+        let cr = json!({
+            "apiVersion": "kyverno.io/v1",
+            "kind": "ClusterPolicy",
+            "metadata": { "name": "my-policy" }
+        });
+        let manifests = vec![cr];
+        let client = SelectiveApiResourceNotFoundClient::new([("kyverno.io", "v1", "ClusterPolicy")]);
+        let result = compute_diff_from_live(&client, &manifests, None, DiffMode::Raw)
+            .await
+            .unwrap();
+
+        let cr_entry = result.added.iter().find(|(k, _)| k.gvk.kind == "ClusterPolicy");
+        assert!(cr_entry.is_some(), "ClusterPolicy should appear in added");
+        let note = cr_entry.unwrap().1.as_ref().expect("should have a note");
+        assert!(note.is_error, "note should be an error when CRD is not in manifests");
+        assert!(note.message.contains("CRD not installed"));
+        assert_eq!(result.total_error_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_diff_api_resource_not_found_wrong_version_counts_as_error() {
+        // CRD in manifests but only serves v1beta1, resource requests v1
+        let crd = json!({
+            "apiVersion": "apiextensions.k8s.io/v1",
+            "kind": "CustomResourceDefinition",
+            "metadata": { "name": "mypolicies.kyverno.io" },
+            "spec": {
+                "group": "kyverno.io",
+                "names": { "kind": "ClusterPolicy", "plural": "clusterpolicies" },
+                "versions": [{ "name": "v1beta1", "served": true, "storage": true }],
+                "scope": "Cluster"
+            }
+        });
+        let cr = json!({
+            "apiVersion": "kyverno.io/v1",
+            "kind": "ClusterPolicy",
+            "metadata": { "name": "my-policy" }
+        });
+        let manifests = vec![crd, cr];
+        let client = SelectiveApiResourceNotFoundClient::new([("kyverno.io", "v1", "ClusterPolicy")]);
+        let result = compute_diff_from_live(&client, &manifests, None, DiffMode::Raw)
+            .await
+            .unwrap();
+
+        let cr_entry = result.added.iter().find(|(k, _)| k.gvk.kind == "ClusterPolicy");
+        assert!(cr_entry.is_some());
+        let note = cr_entry.unwrap().1.as_ref().expect("should have a note");
+        assert!(note.is_error, "should be an error: CRD in manifests but wrong version");
+        assert_eq!(result.total_error_count(), 1);
     }
 }

--- a/nyl/src/cli/commands/diff.rs
+++ b/nyl/src/cli/commands/diff.rs
@@ -8,7 +8,8 @@ use crate::{
         namespace_resolution::{adjust_duplicate_keys_for_namespace_resolution, resolve_manifest_namespaces},
     },
     kubernetes::{
-        extract_name, DiffEngine, KubeClient, KubernetesReleaseStorage, ReleaseStatus, ReleaseStorage, ResourceKey,
+        extract_name, DiffEngine, GroupVersionKind, KubeClient, KubernetesReleaseStorage, ReleaseStatus,
+        ReleaseStorage, ResourceKey,
     },
     NylError, Result,
 };
@@ -201,10 +202,17 @@ pub fn extract_component_name(manifests: &[serde_json::Value]) -> Result<String>
     Ok(name)
 }
 
+/// Annotation attached to an added resource
+#[derive(Debug)]
+struct AddedNote {
+    message: String,
+    is_error: bool,
+}
+
 /// Diff result categorization
 #[derive(Debug)]
 struct DiffResult {
-    added: Vec<ResourceKey>,
+    added: Vec<(ResourceKey, Option<AddedNote>)>,
     modified: Vec<(ResourceKey, String, Option<String>)>, // (key, unified_diff_text, optional_error)
     deleted: Vec<ResourceKey>,
     unchanged: Vec<ResourceKey>,
@@ -212,10 +220,15 @@ struct DiffResult {
 }
 
 impl DiffResult {
-    /// Count total errors including normalization failures
+    /// Count total errors including normalization failures and added resources with errors
     fn total_error_count(&self) -> usize {
         let normalization_errors = self.modified.iter().filter(|(_, _, err)| err.is_some()).count();
-        self.errors.len() + normalization_errors
+        let added_errors = self
+            .added
+            .iter()
+            .filter(|(_, note)| note.as_ref().is_some_and(|n| n.is_error))
+            .count();
+        self.errors.len() + normalization_errors + added_errors
     }
 }
 
@@ -234,15 +247,19 @@ async fn compute_diff_from_live(
 
     // Fetch live resources for desired manifests
     let mut live_resources = HashMap::new();
+    let mut crd_not_found_keys: HashSet<ResourceKey> = HashSet::new();
     for manifest in desired_manifests {
         let key = ResourceKey::from_json_value(manifest)?;
-        if let Some(resource) = client
-            .get_resource(&key.gvk, key.namespace.as_deref(), &key.name)
-            .await?
-        {
-            // Convert DynamicObject to JSON for comparison
-            let live_json = serde_json::to_value(&resource)?;
-            live_resources.insert(key.clone(), live_json);
+        match client.get_resource(&key.gvk, key.namespace.as_deref(), &key.name).await {
+            Ok(Some(resource)) => {
+                let live_json = serde_json::to_value(&resource)?;
+                live_resources.insert(key.clone(), live_json);
+            }
+            Ok(None) => {}
+            Err(e) if e.is_api_resource_not_found_error() => {
+                crd_not_found_keys.insert(key);
+            }
+            Err(e) => return Err(e),
         }
     }
 
@@ -254,12 +271,14 @@ async fn compute_diff_from_live(
     for key in &previous_keys {
         if !desired_keys.contains(key) {
             // This resource is being deleted - check if it still exists in cluster
-            if let Some(resource) = client
-                .get_resource(&key.gvk, key.namespace.as_deref(), &key.name)
-                .await?
-            {
-                let live_json = serde_json::to_value(&resource)?;
-                live_resources.insert(key.clone(), live_json);
+            match client.get_resource(&key.gvk, key.namespace.as_deref(), &key.name).await {
+                Ok(Some(resource)) => {
+                    let live_json = serde_json::to_value(&resource)?;
+                    live_resources.insert(key.clone(), live_json);
+                }
+                Ok(None) => {}
+                Err(e) if e.is_api_resource_not_found_error() => {}
+                Err(e) => return Err(e),
             }
         }
     }
@@ -322,7 +341,22 @@ async fn compute_diff_from_live(
                 }
             }
         } else {
-            added.push(key);
+            let note = if crd_not_found_keys.contains(&key) {
+                if crd_in_manifests(&key.gvk, desired_manifests) {
+                    Some(AddedNote {
+                        message: "CRD will be installed".to_string(),
+                        is_error: false,
+                    })
+                } else {
+                    Some(AddedNote {
+                        message: "CRD not installed in cluster".to_string(),
+                        is_error: true,
+                    })
+                }
+            } else {
+                None
+            };
+            added.push((key, note));
         }
     }
 
@@ -377,9 +411,10 @@ fn print_summary(diff: &DiffResult, duplicates: &HashMap<ResourceKey, usize>) {
 /// Display diff results with kubectl-style unified diff output
 fn display_diff(diff: &DiffResult, duplicates: &HashMap<ResourceKey, usize>) {
     // Show added resources
-    for key in &diff.added {
+    for (key, note) in &diff.added {
         let dup_annotation = get_duplicate_annotation_for_key(key, duplicates);
-        println!("{} {}{}", "+".green().bold(), key, dup_annotation);
+        let note_annotation = format_added_note(note);
+        println!("{} {}{}{}", "+".green().bold(), key, dup_annotation, note_annotation);
     }
     if !diff.added.is_empty() {
         println!();
@@ -432,8 +467,33 @@ fn display_diff(diff: &DiffResult, duplicates: &HashMap<ResourceKey, usize>) {
     print_summary(diff, duplicates);
 }
 
-/// Display summary only (counts, no detailed diff)
+/// Display resource list and counts, without unified diff content
 fn display_summary(diff: &DiffResult, duplicates: &HashMap<ResourceKey, usize>) {
+    for (key, note) in &diff.added {
+        let dup_annotation = get_duplicate_annotation_for_key(key, duplicates);
+        let note_annotation = format_added_note(note);
+        println!("{} {}{}{}", "+".green().bold(), key, dup_annotation, note_annotation);
+    }
+
+    for (key, _, error) in &diff.modified {
+        let dup_annotation = get_duplicate_annotation_for_key(key, duplicates);
+        let error_annotation = if let Some(err) = error {
+            format!(" {}", format!("({})", err).red())
+        } else {
+            String::new()
+        };
+        println!("{} {}{}{}", "~".yellow().bold(), key, dup_annotation, error_annotation);
+    }
+
+    for key in &diff.deleted {
+        let dup_annotation = get_duplicate_annotation_for_key(key, duplicates);
+        println!("{} {}{}", "-".red().bold(), key, dup_annotation);
+    }
+
+    if !diff.added.is_empty() || !diff.modified.is_empty() || !diff.deleted.is_empty() {
+        println!();
+    }
+
     print_summary(diff, duplicates);
 }
 
@@ -453,6 +513,14 @@ fn print_duplicate_warning(duplicates: &HashMap<ResourceKey, usize>) {
     );
 }
 
+fn format_added_note(note: &Option<AddedNote>) -> String {
+    match note {
+        Some(n) if n.is_error => format!(" {}", format!("({})", n.message).red()),
+        Some(n) => format!(" {}", format!("({})", n.message).yellow()),
+        None => String::new(),
+    }
+}
+
 /// Get duplicate annotation for a ResourceKey if it's a duplicate
 fn get_duplicate_annotation_for_key(key: &ResourceKey, duplicates: &HashMap<ResourceKey, usize>) -> String {
     if let Some(count) = duplicates.get(key) {
@@ -461,6 +529,29 @@ fn get_duplicate_annotation_for_key(key: &ResourceKey, duplicates: &HashMap<Reso
         return format!(" {}", format!("({} {} ignored)", ignored_count, plural).yellow());
     }
     String::new()
+}
+
+fn crd_in_manifests(gvk: &GroupVersionKind, manifests: &[serde_json::Value]) -> bool {
+    manifests.iter().any(|m| {
+        let api_version = m.get("apiVersion").and_then(|v| v.as_str()).unwrap_or("");
+        let kind = m.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+        if kind != "CustomResourceDefinition"
+            || (api_version != "apiextensions.k8s.io/v1" && api_version != "apiextensions.k8s.io/v1beta1")
+        {
+            return false;
+        }
+        let spec = m.get("spec");
+        let group_matches = spec
+            .and_then(|s| s.get("group"))
+            .and_then(|g| g.as_str())
+            .is_some_and(|g| g == gvk.group);
+        let kind_matches = spec
+            .and_then(|s| s.get("names"))
+            .and_then(|n| n.get("kind"))
+            .and_then(|k| k.as_str())
+            .is_some_and(|k| k == gvk.kind);
+        group_matches && kind_matches
+    })
 }
 
 fn missing_release_warning_message(namespace: &str, release_name: &str) -> String {

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -520,8 +520,7 @@ fn manifest_requires_namespace_resolution(manifest: &serde_json::Value) -> bool 
         return false;
     }
 
-    crate::kubernetes::extract_gvk(manifest)
-        .map_or(true, |gvk| !crate::kubernetes::is_known_cluster_scoped_gvk(&gvk))
+    crate::kubernetes::extract_gvk(manifest).map_or(true, |gvk| !crate::kubernetes::is_known_cluster_scoped_gvk(&gvk))
 }
 
 /// Load YAML/JSON resources from a file path, rendering Jinja templates.

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -521,8 +521,7 @@ fn manifest_requires_namespace_resolution(manifest: &serde_json::Value) -> bool 
     }
 
     crate::kubernetes::extract_gvk(manifest)
-        .map(|gvk| !crate::kubernetes::is_known_cluster_scoped_gvk(&gvk))
-        .unwrap_or(true)
+        .map_or(true, |gvk| !crate::kubernetes::is_known_cluster_scoped_gvk(&gvk))
 }
 
 /// Load YAML/JSON resources from a file path, rendering Jinja templates.

--- a/nyl/src/cli/namespace_resolution.rs
+++ b/nyl/src/cli/namespace_resolution.rs
@@ -183,7 +183,6 @@ fn set_manifest_namespace(manifest: &mut Value, namespace: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::error::API_RESOURCE_NOT_FOUND_PREFIX;
     use crate::kubernetes::{ApplyOutcome, GroupVersionKind, MockKubeClient};
     use async_trait::async_trait;
     use kube::api::DynamicObject;
@@ -312,8 +311,8 @@ mod tests {
                 let mut counts = self.call_counts.lock().unwrap();
                 *counts.entry(gvk.clone()).or_insert(0) += 1;
             }
-            Err(NylError::Config(format!(
-                "{API_RESOURCE_NOT_FOUND_PREFIX}{}/{}",
+            Err(NylError::ApiResourceNotFound(format!(
+                "{}/{}",
                 if gvk.group.is_empty() {
                     gvk.version.clone()
                 } else {

--- a/nyl/src/cli/namespace_resolution.rs
+++ b/nyl/src/cli/namespace_resolution.rs
@@ -27,9 +27,7 @@ pub async fn resolve_manifest_namespaces(
         if key
             .namespace
             .as_deref()
-            .map(str::trim)
-            .filter(|ns| !ns.is_empty())
-            .is_some()
+            .is_some_and(|ns| !ns.trim().is_empty())
         {
             continue;
         }
@@ -102,9 +100,7 @@ pub async fn adjust_duplicate_keys_for_namespace_resolution(
         if key
             .namespace
             .as_deref()
-            .map(str::trim)
-            .filter(|ns| !ns.is_empty())
-            .is_some()
+            .is_some_and(|ns| !ns.trim().is_empty())
         {
             adjusted.insert(key.clone(), *count);
             continue;

--- a/nyl/src/cli/namespace_resolution.rs
+++ b/nyl/src/cli/namespace_resolution.rs
@@ -24,11 +24,7 @@ pub async fn resolve_manifest_namespaces(
 
     for manifest in manifests {
         let key = ResourceKey::from_json_value(manifest)?;
-        if key
-            .namespace
-            .as_deref()
-            .is_some_and(|ns| !ns.trim().is_empty())
-        {
+        if key.namespace.as_deref().is_some_and(|ns| !ns.trim().is_empty()) {
             continue;
         }
 
@@ -97,11 +93,7 @@ pub async fn adjust_duplicate_keys_for_namespace_resolution(
     let default_namespace = client.default_namespace();
 
     for (key, count) in duplicates {
-        if key
-            .namespace
-            .as_deref()
-            .is_some_and(|ns| !ns.trim().is_empty())
-        {
+        if key.namespace.as_deref().is_some_and(|ns| !ns.trim().is_empty()) {
             adjusted.insert(key.clone(), *count);
             continue;
         }

--- a/nyl/src/error.rs
+++ b/nyl/src/error.rs
@@ -12,7 +12,7 @@ pub enum NylError {
     #[error("Configuration error: {0}\nHint: Check your nyl.toml syntax and structure. Run 'nyl validate --strict' for detailed validation.")]
     Config(String),
 
-    #[error("API resource not found: {0}\nHint: The CRD for this resource type may not be installed in the cluster.")]
+    #[error("API resource not found: {0}\nHint: The CRD for this resource type may not be installed, or the apiVersion/kind may not be supported by the cluster.")]
     ApiResourceNotFound(String),
 
     #[error("Configuration file not found: {0}\nHint: Create a new project with 'nyl new project <name>' or ensure you're in a directory with a valid nyl.toml file.")]

--- a/nyl/src/error.rs
+++ b/nyl/src/error.rs
@@ -1,7 +1,5 @@
 use thiserror::Error;
 
-pub(crate) const API_RESOURCE_NOT_FOUND_PREFIX: &str = "API resource not found for ";
-
 /// Main error type for nyl
 #[derive(Error, Debug)]
 pub enum NylError {
@@ -13,6 +11,9 @@ pub enum NylError {
 
     #[error("Configuration error: {0}\nHint: Check your nyl.toml syntax and structure. Run 'nyl validate --strict' for detailed validation.")]
     Config(String),
+
+    #[error("API resource not found: {0}\nHint: The CRD for this resource type may not be installed in the cluster.")]
+    ApiResourceNotFound(String),
 
     #[error("Configuration file not found: {0}\nHint: Create a new project with 'nyl new project <name>' or ensure you're in a directory with a valid nyl.toml file.")]
     ConfigNotFound(String),
@@ -119,7 +120,7 @@ impl NylError {
 
     /// Returns true if this is an API discovery miss for a specific GVK.
     pub fn is_api_resource_not_found_error(&self) -> bool {
-        matches!(self, NylError::Config(message) if message.starts_with(API_RESOURCE_NOT_FOUND_PREFIX))
+        matches!(self, NylError::ApiResourceNotFound(_))
     }
 }
 
@@ -215,7 +216,7 @@ mod tests {
 
     #[test]
     fn test_is_api_resource_not_found_error() {
-        let err = NylError::Config(format!("{API_RESOURCE_NOT_FOUND_PREFIX}kyverno.io/v1/ClusterPolicy"));
+        let err = NylError::ApiResourceNotFound("kyverno.io/v1/ClusterPolicy".to_string());
         assert!(err.is_api_resource_not_found_error());
 
         let other = NylError::Config("some other config error".to_string());

--- a/nyl/src/git/argocd.rs
+++ b/nyl/src/git/argocd.rs
@@ -182,7 +182,7 @@ impl ArgoCDCredentialDiscovery {
 
         // Combine both sets of secrets, filtering for type="git" only
         let mut secrets = HashMap::new();
-        for secret in repo_secrets.items.into_iter().chain(creds_secrets.items.into_iter()) {
+        for secret in repo_secrets.items.into_iter().chain(creds_secrets.items) {
             // Check if secret type is "git" (or not specified, which defaults to "git")
             let repo_type = secret
                 .data

--- a/nyl/src/kubernetes/client.rs
+++ b/nyl/src/kubernetes/client.rs
@@ -9,7 +9,6 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use crate::{
-    error::API_RESOURCE_NOT_FOUND_PREFIX,
     kubernetes::resource::{ApplyOutcome, GroupVersionKind, ResourceKey},
     profiles::{KubeconfigSource, Profile},
     NylError, Result,
@@ -213,8 +212,8 @@ impl KubeRsClient {
             format!(" (available versions for this kind: {})", available_versions.join(", "))
         };
 
-        Err(NylError::Config(format!(
-            "{API_RESOURCE_NOT_FOUND_PREFIX}{}/{}{}",
+        Err(NylError::ApiResourceNotFound(format!(
+            "{}/{}{}",
             group_version, gvk.kind, versions_hint
         )))
     }

--- a/nyl/src/postprocess/kyverno.rs
+++ b/nyl/src/postprocess/kyverno.rs
@@ -91,8 +91,7 @@ fn is_kyverno_installed() -> bool {
     Command::new("kyverno")
         .arg("version")
         .output()
-        .map(|output| output.status.success())
-        .unwrap_or(false)
+        .is_ok_and(|output| output.status.success())
 }
 
 /// Write manifests to a YAML file

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,12 @@
     },
     "packageRules": [
         {
+            "description": "Group rust-toolchain.toml and mise.toml Rust version bumps into a single PR",
+            "matchManagers": ["rust-toolchain", "mise"],
+            "matchPackageNames": ["rust"],
+            "groupName": "Rust toolchain"
+        },
+        {
             "description": "Auto-merge security/vulnerability patches immediately",
             "matchCategories": ["rust"],
             "matchUpdateTypes": ["patch"],

--- a/renovate.json
+++ b/renovate.json
@@ -11,9 +11,9 @@
     },
     "packageRules": [
         {
-            "description": "Group rust-toolchain.toml and mise.toml Rust version bumps into a single PR",
-            "matchManagers": ["rust-toolchain", "mise"],
-            "matchPackageNames": ["rust"],
+            "description": "Group rust-toolchain.toml, mise.toml, and CI action Rust version bumps into a single PR",
+            "matchManagers": ["rust-toolchain", "mise", "github-actions"],
+            "matchPackageNames": ["rust", "dtolnay/rust-toolchain"],
             "groupName": "Rust toolchain"
         },
         {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.95.0"


### PR DESCRIPTION
## Summary

- Introduce `NylError::ApiResourceNotFound` (replaces the overloaded `NylError::Config` path for API discovery misses), with a hint pointing to the CRD not being installed rather than the unrelated nyl.toml message.
- `nyl diff` no longer aborts when a resource's CRD is unknown to the cluster — the resource is shown as added (`+`) with an inline annotation:
  - **(CRD will be installed)** in yellow when the CRD itself is present in the same manifest being diffed.
  - **(CRD not installed in cluster)** in red when the CRD is absent — counted as an error, exit code 2, incremented "N failed" in the summary line.
- `nyl diff --summary` now shows the per-resource list (added/modified/deleted with `+`/`~`/`-`) before the counts line, instead of only the counts line.
- Fix 6 new Clippy lints introduced in Rust 1.95 (`map_unwrap_or`, `manual_is_variant_and`, `useless_conversion`, `unnecessary_literal_bound`); add `rust-toolchain.toml` pinned to `1.95.0` so local dev and CI stay on the same toolchain version.

## Test plan

- [x] `cargo test` passes
- [x] `nyl diff <manifest-with-unknown-crd-resource>` → shows `+ resource (CRD not installed in cluster)` in red, exits 2
- [x] `nyl diff <manifest-that-also-includes-the-crd>` → shows `+ resource (CRD will be installed)` in yellow, exits 0
- [x] `nyl diff --summary` → prints resource list then summary counts, no diff hunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)