### PR TITLE
feat(helm): include CRDs in helm template output by default

### DIFF
--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -860,6 +860,7 @@ async fn generate_resource(
                 spec: crate::resources::HelmChartSpec {
                     chart: chart_ref,
                     values: component.spec,
+                    include_crds: None,
                 },
             };
 
@@ -899,6 +900,7 @@ async fn generate_resource(
                         ..Default::default()
                     },
                     values: component.spec,
+                    include_crds: None,
                 },
             };
 
@@ -1132,7 +1134,8 @@ fn render_helm_chart(
 
     let executor = HelmTemplateExecutor::new()
         .with_kube_version(kube_version.to_string())
-        .with_api_versions(api_versions.to_vec());
+        .with_api_versions(api_versions.to_vec())
+        .with_include_crds(chart.spec.include_crds.unwrap_or(true));
 
     // Default namespace to "default" for deterministic rendering
     let namespace = chart.release_namespace().or(Some("default"));

--- a/nyl/src/helm/template.rs
+++ b/nyl/src/helm/template.rs
@@ -24,6 +24,9 @@ pub struct HelmTemplateExecutor {
 
     /// API versions to pass to Helm
     api_versions: Vec<String>,
+
+    /// Whether to pass --include-crds to helm template (default: true)
+    include_crds: bool,
 }
 
 impl HelmTemplateExecutor {
@@ -32,6 +35,7 @@ impl HelmTemplateExecutor {
         Self {
             kube_version: None,
             api_versions: Vec::new(),
+            include_crds: true,
         }
     }
 
@@ -46,6 +50,13 @@ impl HelmTemplateExecutor {
     #[must_use]
     pub fn with_api_versions(mut self, versions: Vec<String>) -> Self {
         self.api_versions = versions;
+        self
+    }
+
+    /// Set whether to include CRDs in the rendered output (default: true)
+    #[must_use]
+    pub fn with_include_crds(mut self, include_crds: bool) -> Self {
+        self.include_crds = include_crds;
         self
     }
 
@@ -87,6 +98,11 @@ impl HelmTemplateExecutor {
         if let Some(file_path) = params.values_file {
             cmd.arg("--values");
             cmd.arg(file_path);
+        }
+
+        // Include CRDs from the chart's crds/ directory
+        if self.include_crds {
+            cmd.arg("--include-crds");
         }
 
         cmd
@@ -180,6 +196,7 @@ impl std::fmt::Debug for HelmTemplateExecutor {
         f.debug_struct("HelmTemplateExecutor")
             .field("kube_version", &self.kube_version)
             .field("api_versions", &self.api_versions)
+            .field("include_crds", &self.include_crds)
             .finish()
     }
 }
@@ -321,6 +338,40 @@ mod tests {
         assert!(args.contains(&"--api-versions".to_string()));
         assert!(args.contains(&"apps/v1".to_string()));
         assert!(args.contains(&"v1".to_string()));
+    }
+
+    #[test]
+    fn test_build_command_includes_crds_by_default() {
+        let executor = HelmTemplateExecutor::new();
+        let resolved = ResolvedChart {
+            path: PathBuf::from("/charts/nginx"),
+            chart_ref: ChartRef::default(),
+        };
+        let cmd = executor.build_command(HelmTemplateParams {
+            resolved: &resolved,
+            release_name: "my-release",
+            release_namespace: None,
+            values_file: None,
+        });
+        let args: Vec<String> = cmd.get_args().map(|s| s.to_string_lossy().to_string()).collect();
+        assert!(args.contains(&"--include-crds".to_string()));
+    }
+
+    #[test]
+    fn test_build_command_include_crds_disabled() {
+        let executor = HelmTemplateExecutor::new().with_include_crds(false);
+        let resolved = ResolvedChart {
+            path: PathBuf::from("/charts/nginx"),
+            chart_ref: ChartRef::default(),
+        };
+        let cmd = executor.build_command(HelmTemplateParams {
+            resolved: &resolved,
+            release_name: "my-release",
+            release_namespace: None,
+            values_file: None,
+        });
+        let args: Vec<String> = cmd.get_args().map(|s| s.to_string_lossy().to_string()).collect();
+        assert!(!args.contains(&"--include-crds".to_string()));
     }
 
     #[test]

--- a/nyl/src/resources/helmchart.rs
+++ b/nyl/src/resources/helmchart.rs
@@ -99,6 +99,11 @@ pub struct HelmChartSpec {
     /// Values to pass to the chart
     #[serde(default)]
     pub values: serde_json::Value,
+
+    /// Whether to include CRDs from the chart's crds/ directory in the rendered output.
+    /// Defaults to true when unset.
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "includeCrds")]
+    pub include_crds: Option<bool>,
 }
 
 impl Default for HelmChartSpec {
@@ -106,6 +111,7 @@ impl Default for HelmChartSpec {
         Self {
             chart: ChartRef::default(),
             values: serde_json::Value::Object(serde_json::Map::new()),
+            include_crds: None,
         }
     }
 }

--- a/nyl/src/resources/helmchart.rs
+++ b/nyl/src/resources/helmchart.rs
@@ -285,6 +285,67 @@ mod tests {
     fn test_helm_chart_spec_defaults() {
         let spec = HelmChartSpec::default();
         assert!(spec.values.is_object());
+        assert_eq!(spec.include_crds, None);
+    }
+
+    #[test]
+    fn test_helm_chart_spec_include_crds_explicit_false() {
+        let yaml = r"
+apiVersion: nyl.niklasrosenstein.github.com/v1
+kind: HelmChart
+metadata:
+  name: test
+spec:
+  chart:
+    name: mychart
+  includeCrds: false
+";
+        let result: HelmChart = serde_norway::from_str(yaml).unwrap();
+        assert_eq!(result.spec.include_crds, Some(false));
+    }
+
+    #[test]
+    fn test_helm_chart_spec_include_crds_explicit_true() {
+        let yaml = r"
+apiVersion: nyl.niklasrosenstein.github.com/v1
+kind: HelmChart
+metadata:
+  name: test
+spec:
+  chart:
+    name: mychart
+  includeCrds: true
+";
+        let result: HelmChart = serde_norway::from_str(yaml).unwrap();
+        assert_eq!(result.spec.include_crds, Some(true));
+    }
+
+    #[test]
+    fn test_helm_chart_spec_include_crds_omitted_is_none() {
+        let yaml = r"
+apiVersion: nyl.niklasrosenstein.github.com/v1
+kind: HelmChart
+metadata:
+  name: test
+spec:
+  chart:
+    name: mychart
+";
+        let result: HelmChart = serde_norway::from_str(yaml).unwrap();
+        assert_eq!(result.spec.include_crds, None);
+    }
+
+    #[test]
+    fn test_helm_chart_spec_include_crds_not_serialized_when_none() {
+        let helm_chart = HelmChart::new(
+            "test",
+            ChartRef {
+                name: Some("mychart".to_string()),
+                ..Default::default()
+            },
+        );
+        let yaml = serde_norway::to_string(&helm_chart).unwrap();
+        assert!(!yaml.contains("includeCrds"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `helm template` does not render CRDs from a chart's `crds/` directory unless `--include-crds` is passed. This flag is now added to all `HelmTemplateExecutor` invocations, so CRDs are included by default.
- An opt-out is available via `includeCrds: false` in the `HelmChart` spec for the rare cases where CRD rendering should be suppressed.

## Test plan

- [ ] `cargo test` passes (includes unit tests asserting `--include-crds` is present/absent based on config)
- [x] `nyl diff <chart-with-crds>` now renders CRDs as new resources instead of silently omitting them
- [ ] Setting `includeCrds: false` in a HelmChart spec suppresses CRD output

🤖 Generated with [Claude Code](https://claude.com/claude-code)