### PR TITLE
feat(remote-manifest): support multiple URLs with parameter substitution

### DIFF
--- a/nyl/book/src/reference/resources/remote-manifest.md
+++ b/nyl/book/src/reference/resources/remote-manifest.md
@@ -1,6 +1,6 @@
 # RemoteManifest
 
-`RemoteManifest` fetches YAML/JSON documents from a remote HTTPS URL and feeds
+`RemoteManifest` fetches YAML/JSON documents from one or more remote HTTPS URLs and feeds
 them into Nyl's normal render pipeline.
 
 ## API Version
@@ -8,6 +8,8 @@ them into Nyl's normal render pipeline.
 - `nyl.niklasrosenstein.github.com/v1`
 
 ## Schema
+
+Single URL (legacy form):
 
 ```yaml
 apiVersion: nyl.niklasrosenstein.github.com/v1
@@ -19,26 +21,47 @@ spec:
   overrideNamespace: false
 ```
 
+Multiple URLs with parameter substitution:
+
+```yaml
+apiVersion: nyl.niklasrosenstein.github.com/v1
+kind: RemoteManifest
+metadata:
+  name: <name>
+spec:
+  params:
+    version: 1.2.3
+  sources:
+    - https://example.com/v{version}/crd-a.yaml
+    - https://example.com/v{version}/crd-b.yaml
+  overrideNamespace: false
+```
+
 ### Fields
 
-- `spec.url` (required): HTTPS URL containing one or more YAML/JSON documents.
+- `spec.url` (mutually exclusive with `spec.sources`): Single HTTPS URL containing one or more YAML/JSON documents.
+- `spec.sources` (mutually exclusive with `spec.url`): List of HTTPS URL templates. Each entry may contain `{key}` placeholders resolved from `spec.params`.
+- `spec.params` (optional, requires `spec.sources`): Map of parameter names to string values used for `{key}` substitution in `spec.sources` URLs.
 - `spec.overrideNamespace` (optional, default `false`): when `true`, fetched resources that already have `metadata.namespace` will have that value replaced with `RemoteManifest.metadata.namespace`.
 
 ## Behavior
 
-- URL must use `https://`.
+- All URLs must use `https://`.
 - Fetching uses Nyl's native HTTPS client (no shell-out), with HTTPS-only redirect policy.
-- Request timeouts are enforced (connect: 5s, total: 30s).
-- Response size is limited to 30 MiB; larger payloads fail fast.
+- Request timeouts are enforced per URL (connect: 5s, total: 30s).
+- Response size is limited to 30 MiB per URL; larger payloads fail fast.
 - Content is parsed as YAML multi-document stream.
+- When `spec.sources` is used, documents from all URLs are concatenated in order.
 - Parsed resources are processed recursively like local resources.
 - Remote content is not rendered as a Jinja template.
-- When `spec.overrideNamespace: true`, remote manifests with `metadata.namespace` are rewritten to `RemoteManifest.metadata.namespace`.
+- When `spec.overrideNamespace: true`, remote manifests with `metadata.namespace` are rewritten to `RemoteManifest.metadata.namespace` (applied after all URLs are fetched).
 - Special case: for `RoleBinding` and `ClusterRoleBinding` (`rbac.authorization.k8s.io/*`), `subjects[*].namespace` is also rewritten (ServiceAccount subjects are forced to the override namespace).
 - Potential future rewrite targets (currently not handled): webhook service namespaces (`MutatingWebhookConfiguration`, `ValidatingWebhookConfiguration`, CRD conversion webhook), and `APIService.spec.service.namespace`.
 - Fetch or parse failures stop the command (`render`, `diff`, `apply`).
 
-## Example
+## Examples
+
+### Single URL
 
 ```yaml
 apiVersion: nyl.niklasrosenstein.github.com/v1
@@ -47,4 +70,22 @@ metadata:
   name: shared-crds
 spec:
   url: https://example.com/platform/crds.yaml
+```
+
+### Multiple URLs with a shared version parameter
+
+```yaml
+apiVersion: nyl.niklasrosenstein.github.com/v1
+kind: RemoteManifest
+metadata:
+  name: gateway-api-crds
+  namespace: nginx-gateway
+spec:
+  params:
+    # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api versioning=semver
+    version: 1.5.1
+  sources:
+    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v{version}/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v{version}/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v{version}/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
 ```

--- a/nyl/book/src/reference/resources/remote-manifest.md
+++ b/nyl/book/src/reference/resources/remote-manifest.md
@@ -31,7 +31,7 @@ metadata:
 spec:
   params:
     version: 1.2.3
-  sources:
+  urls:
     - https://example.com/v{version}/crd-a.yaml
     - https://example.com/v{version}/crd-b.yaml
   overrideNamespace: false
@@ -39,9 +39,9 @@ spec:
 
 ### Fields
 
-- `spec.url` (mutually exclusive with `spec.sources`): Single HTTPS URL containing one or more YAML/JSON documents.
-- `spec.sources` (mutually exclusive with `spec.url`): List of HTTPS URL templates. Each entry may contain `{key}` placeholders resolved from `spec.params`.
-- `spec.params` (optional, requires `spec.sources`): Map of parameter names to string values used for `{key}` substitution in `spec.sources` URLs.
+- `spec.url` (mutually exclusive with `spec.urls`): Single HTTPS URL containing one or more YAML/JSON documents.
+- `spec.urls` (mutually exclusive with `spec.url`): List of HTTPS URL templates. Each entry may contain `{key}` placeholders resolved from `spec.params`.
+- `spec.params` (optional, requires `spec.urls`): Map of parameter names to string values used for `{key}` substitution in `spec.urls` URLs.
 - `spec.overrideNamespace` (optional, default `false`): when `true`, fetched resources that already have `metadata.namespace` will have that value replaced with `RemoteManifest.metadata.namespace`.
 
 ## Behavior
@@ -51,7 +51,7 @@ spec:
 - Request timeouts are enforced per URL (connect: 5s, total: 30s).
 - Response size is limited to 30 MiB per URL; larger payloads fail fast.
 - Content is parsed as YAML multi-document stream.
-- When `spec.sources` is used, documents from all URLs are concatenated in order.
+- When `spec.urls` is used, documents from all URLs are concatenated in order.
 - Parsed resources are processed recursively like local resources.
 - Remote content is not rendered as a Jinja template.
 - When `spec.overrideNamespace: true`, remote manifests with `metadata.namespace` are rewritten to `RemoteManifest.metadata.namespace` (applied after all URLs are fetched).
@@ -84,7 +84,7 @@ spec:
   params:
     # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api versioning=semver
     version: 1.5.1
-  sources:
+  urls:
     - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v{version}/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
     - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v{version}/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
     - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v{version}/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -952,8 +952,6 @@ async fn generate_resource(
 }
 
 async fn fetch_remote_manifest_documents(remote_manifest: &RemoteManifest) -> Result<Vec<serde_json::Value>> {
-    let url = remote_manifest.spec.url.trim();
-    let sanitized_url = crate::util::sanitize_url(url);
     let client = reqwest::Client::builder()
         .connect_timeout(Duration::from_secs(5))
         .timeout(Duration::from_secs(30))
@@ -967,10 +965,29 @@ async fn fetch_remote_manifest_documents(remote_manifest: &RemoteManifest) -> Re
         .build()
         .map_err(|e| {
             NylError::Process(format!(
-                "Failed to initialize HTTPS client for RemoteManifest '{}' from {}: {}",
-                remote_manifest.metadata.name, sanitized_url, e
+                "Failed to initialize HTTPS client for RemoteManifest '{}': {}",
+                remote_manifest.metadata.name, e
             ))
         })?;
+
+    let urls = remote_manifest.resolve_urls()?;
+    let mut all_documents = Vec::new();
+    for url in &urls {
+        let docs = fetch_single_remote_url(&client, remote_manifest, url).await?;
+        all_documents.extend(docs);
+    }
+    if remote_manifest.spec.override_namespace {
+        override_fetched_manifest_namespaces(&mut all_documents, remote_manifest.metadata.namespace.as_deref());
+    }
+    Ok(all_documents)
+}
+
+async fn fetch_single_remote_url(
+    client: &reqwest::Client,
+    remote_manifest: &RemoteManifest,
+    url: &str,
+) -> Result<Vec<serde_json::Value>> {
+    let sanitized_url = crate::util::sanitize_url(url);
     let mut response = client.get(url).send().await.map_err(|e| {
         let detail = if e.is_timeout() {
             "request timed out"
@@ -1024,11 +1041,7 @@ async fn fetch_remote_manifest_documents(remote_manifest: &RemoteManifest) -> Re
         ))
     })?;
     let source_ctx = crate::util::SourceContext::new(PathBuf::from(format!("remote:{sanitized_url}")));
-    let mut documents = source_ctx.parse_yaml_documents(&body)?;
-    if remote_manifest.spec.override_namespace {
-        override_fetched_manifest_namespaces(&mut documents, remote_manifest.metadata.namespace.as_deref());
-    }
-    Ok(documents)
+    source_ctx.parse_yaml_documents(&body)
 }
 
 fn override_fetched_manifest_namespaces(manifests: &mut [serde_json::Value], namespace: Option<&str>) {

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -3,6 +3,7 @@ use glob::{glob, Pattern};
 use kube::Client;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -970,10 +971,25 @@ async fn fetch_remote_manifest_documents(remote_manifest: &RemoteManifest) -> Re
             ))
         })?;
 
+    fetch_remote_manifest_documents_with_fetcher(remote_manifest, |url| {
+        let client = &client;
+        async move { fetch_single_remote_url(client, remote_manifest, &url).await }
+    })
+    .await
+}
+
+async fn fetch_remote_manifest_documents_with_fetcher<F, Fut>(
+    remote_manifest: &RemoteManifest,
+    mut fetcher: F,
+) -> Result<Vec<serde_json::Value>>
+where
+    F: FnMut(String) -> Fut,
+    Fut: Future<Output = Result<Vec<serde_json::Value>>>,
+{
     let urls = remote_manifest.resolve_urls()?;
     let mut all_documents = Vec::new();
-    for url in &urls {
-        let docs = fetch_single_remote_url(&client, remote_manifest, url).await?;
+    for url in urls {
+        let docs = fetcher(url).await?;
         all_documents.extend(docs);
     }
     if remote_manifest.spec.override_namespace {
@@ -2390,7 +2406,7 @@ mod tests {
         ApplicationSource, NylReleaseArgoCdSpec, NylReleaseMetadata, NylReleaseSpec, ReleaseCustomizationPolicy,
     };
     use git2::{Repository, RepositoryInitOptions, Signature};
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::{Arc, Mutex, MutexGuard};
     use tempfile::TempDir;
 
     static APPGEN_OVERRIDE_ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -4012,6 +4028,100 @@ metadata:
         let result = generate_resource(&resource, &context, &config, "", &[], None, false).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("https://"));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_remote_manifest_documents_fetches_urls_in_order_and_overrides_namespaces() {
+        let remote_manifest = RemoteManifest::from_value(&serde_json::json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "remote", "namespace": "target"},
+            "spec": {
+                "overrideNamespace": true,
+                "params": {"version": "1.5.1"},
+                "urls": [
+                    "https://example.com/v{version}/a.yaml",
+                    "https://example.com/v{version}/b.yaml"
+                ]
+            }
+        }))
+        .unwrap();
+        remote_manifest.validate().unwrap();
+
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let calls_for_fetcher = Arc::clone(&calls);
+        let manifests = fetch_remote_manifest_documents_with_fetcher(&remote_manifest, move |url| {
+            let calls = Arc::clone(&calls_for_fetcher);
+            async move {
+                calls.lock().unwrap().push(url.clone());
+                let name = if url.ends_with("/a.yaml") { "a" } else { "b" };
+                Ok(vec![serde_json::json!({
+                    "apiVersion": "v1",
+                    "kind": "ConfigMap",
+                    "metadata": {"name": name, "namespace": "source"}
+                })])
+            }
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(
+            *calls.lock().unwrap(),
+            vec![
+                "https://example.com/v1.5.1/a.yaml".to_string(),
+                "https://example.com/v1.5.1/b.yaml".to_string(),
+            ]
+        );
+        assert_eq!(manifests[0]["metadata"]["name"], "a");
+        assert_eq!(manifests[1]["metadata"]["name"], "b");
+        assert_eq!(manifests[0]["metadata"]["namespace"], "target");
+        assert_eq!(manifests[1]["metadata"]["namespace"], "target");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_remote_manifest_documents_stops_on_first_failed_url() {
+        let remote_manifest = RemoteManifest::from_value(&serde_json::json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "remote"},
+            "spec": {
+                "urls": [
+                    "https://example.com/a.yaml",
+                    "https://example.com/b.yaml",
+                    "https://example.com/c.yaml"
+                ]
+            }
+        }))
+        .unwrap();
+        remote_manifest.validate().unwrap();
+
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let calls_for_fetcher = Arc::clone(&calls);
+        let err = fetch_remote_manifest_documents_with_fetcher(&remote_manifest, move |url| {
+            let calls = Arc::clone(&calls_for_fetcher);
+            async move {
+                calls.lock().unwrap().push(url.clone());
+                if url.ends_with("/b.yaml") {
+                    return Err(NylError::Process(format!("fetch failed for {url}")));
+                }
+                Ok(vec![serde_json::json!({
+                    "apiVersion": "v1",
+                    "kind": "ConfigMap",
+                    "metadata": {"name": "ok"}
+                })])
+            }
+        })
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            *calls.lock().unwrap(),
+            vec![
+                "https://example.com/a.yaml".to_string(),
+                "https://example.com/b.yaml".to_string(),
+            ]
+        );
+        assert!(err.to_string().contains("https://example.com/b.yaml"));
     }
 
     #[test]

--- a/nyl/src/resources/remote_manifest.rs
+++ b/nyl/src/resources/remote_manifest.rs
@@ -1,7 +1,9 @@
 /// RemoteManifest resource definition
 ///
-/// A RemoteManifest fetches YAML/JSON documents from an HTTPS URL and injects
+/// A RemoteManifest fetches YAML/JSON documents from one or more HTTPS URLs and injects
 /// them into the normal render pipeline.
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::constants::API_VERSION;
@@ -12,8 +14,15 @@ use crate::{NylError, Result};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RemoteManifestSpec {
-    /// HTTPS URL to fetch manifest documents from
-    pub url: String,
+    /// Single HTTPS URL to fetch (mutually exclusive with `sources`)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// List of HTTPS URL templates to fetch (mutually exclusive with `url`)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sources: Option<Vec<String>>,
+    /// Parameters for `{key}` substitution in `sources` URL templates
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<HashMap<String, String>>,
     /// Overwrite fetched manifest metadata.namespace with RemoteManifest metadata.namespace
     #[serde(default, rename = "overrideNamespace", skip_serializing_if = "std::ops::Not::not")]
     pub override_namespace: bool,
@@ -49,19 +58,91 @@ impl RemoteManifest {
 
     /// Validate the RemoteManifest configuration
     pub fn validate(&self) -> Result<()> {
-        let url = self.spec.url.trim();
-        if url.is_empty() {
-            return Err(NylError::Config(
-                "RemoteManifest spec.url must not be empty".to_string(),
-            ));
-        }
-        if !url.starts_with("https://") {
-            return Err(NylError::Config(format!(
-                "RemoteManifest spec.url must use https:// scheme, got '{}'",
-                self.spec.url
-            )));
+        match (&self.spec.url, &self.spec.sources) {
+            (Some(_), Some(_)) => {
+                return Err(NylError::Config(
+                    "RemoteManifest spec.url and spec.sources are mutually exclusive".to_string(),
+                ))
+            }
+            (None, None) => {
+                return Err(NylError::Config(
+                    "RemoteManifest must specify either spec.url or spec.sources".to_string(),
+                ))
+            }
+            (Some(url), None) => {
+                if self.spec.params.is_some() {
+                    return Err(NylError::Config(
+                        "RemoteManifest spec.params requires spec.sources".to_string(),
+                    ));
+                }
+                let url = url.trim();
+                if url.is_empty() {
+                    return Err(NylError::Config(
+                        "RemoteManifest spec.url must not be empty".to_string(),
+                    ));
+                }
+                if !url.starts_with("https://") {
+                    return Err(NylError::Config(format!(
+                        "RemoteManifest spec.url must use https:// scheme, got '{url}'"
+                    )));
+                }
+            }
+            (None, Some(sources)) => {
+                if sources.is_empty() {
+                    return Err(NylError::Config(
+                        "RemoteManifest spec.sources must not be empty".to_string(),
+                    ));
+                }
+                for source in sources {
+                    let resolved = match &self.spec.params {
+                        Some(params) => Self::apply_params(source, params)?,
+                        None => source.clone(),
+                    };
+                    if !resolved.trim().starts_with("https://") {
+                        return Err(NylError::Config(format!(
+                            "RemoteManifest spec.sources entry must use https:// scheme, got '{source}'"
+                        )));
+                    }
+                }
+            }
         }
         Ok(())
+    }
+
+    /// Substitute `{key}` placeholders in `template` with values from `params`.
+    pub fn apply_params(template: &str, params: &HashMap<String, String>) -> Result<String> {
+        let mut result = template.to_string();
+        for (key, value) in params {
+            result = result.replace(&format!("{{{key}}}"), value);
+        }
+        if let Some(start) = result.find('{') {
+            if let Some(rel_end) = result[start..].find('}') {
+                let placeholder = &result[start..=start + rel_end];
+                return Err(NylError::Config(format!(
+                    "Unresolved placeholder '{placeholder}' in RemoteManifest URL template '{template}'"
+                )));
+            }
+        }
+        Ok(result)
+    }
+
+    /// Resolve the list of concrete HTTPS URLs to fetch.
+    pub fn resolve_urls(&self) -> Result<Vec<String>> {
+        if let Some(url) = &self.spec.url {
+            Ok(vec![url.trim().to_string()])
+        } else if let Some(sources) = &self.spec.sources {
+            sources
+                .iter()
+                .map(|s| match &self.spec.params {
+                    Some(params) => Self::apply_params(s, params),
+                    None => Ok(s.clone()),
+                })
+                .collect()
+        } else {
+            Err(NylError::Config(
+                "RemoteManifest must specify either spec.url or spec.sources".to_string(),
+            ))
+        }
     }
 }
 
@@ -118,6 +199,111 @@ mod tests {
     }
 
     #[test]
+    fn test_remote_manifest_validate_rejects_neither_url_nor_sources() {
+        let manifest = json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "remote"},
+            "spec": {}
+        });
+        let remote = RemoteManifest::from_value(&manifest).unwrap();
+        let err = remote.validate().unwrap_err();
+        assert!(err.to_string().contains("spec.url or spec.sources"));
+    }
+
+    #[test]
+    fn test_remote_manifest_validate_rejects_both_url_and_sources() {
+        let manifest = json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "remote"},
+            "spec": {
+                "url": "https://example.com/a.yaml",
+                "sources": ["https://example.com/b.yaml"]
+            }
+        });
+        let remote = RemoteManifest::from_value(&manifest).unwrap();
+        let err = remote.validate().unwrap_err();
+        assert!(err.to_string().contains("mutually exclusive"));
+    }
+
+    #[test]
+    fn test_remote_manifest_validate_rejects_params_without_sources() {
+        let manifest = json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "remote"},
+            "spec": {
+                "url": "https://example.com/a.yaml",
+                "params": {"version": "1.0.0"}
+            }
+        });
+        let remote = RemoteManifest::from_value(&manifest).unwrap();
+        let err = remote.validate().unwrap_err();
+        assert!(err.to_string().contains("spec.params requires spec.sources"));
+    }
+
+    #[test]
+    fn test_remote_manifest_validate_rejects_empty_sources() {
+        let manifest = json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "remote"},
+            "spec": {"sources": []}
+        });
+        let remote = RemoteManifest::from_value(&manifest).unwrap();
+        let err = remote.validate().unwrap_err();
+        assert!(err.to_string().contains("spec.sources must not be empty"));
+    }
+
+    #[test]
+    fn test_remote_manifest_validate_rejects_non_https_in_sources() {
+        let manifest = json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "remote"},
+            "spec": {"sources": ["https://example.com/a.yaml", "http://example.com/b.yaml"]}
+        });
+        let remote = RemoteManifest::from_value(&manifest).unwrap();
+        let err = remote.validate().unwrap_err();
+        assert!(err.to_string().contains("https://"));
+    }
+
+    #[test]
+    fn test_remote_manifest_validate_accepts_sources_with_params() {
+        let manifest = json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "remote"},
+            "spec": {
+                "params": {"version": "1.5.1"},
+                "sources": [
+                    "https://example.com/v{version}/a.yaml",
+                    "https://example.com/v{version}/b.yaml"
+                ]
+            }
+        });
+        let remote = RemoteManifest::from_value(&manifest).unwrap();
+        remote.validate().unwrap();
+    }
+
+    #[test]
+    fn test_remote_manifest_validate_rejects_unresolved_placeholder_in_sources() {
+        let manifest = json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "remote"},
+            "spec": {
+                "params": {"version": "1.5.1"},
+                "sources": ["https://example.com/{version}/{unknown}/a.yaml"]
+            }
+        });
+        let remote = RemoteManifest::from_value(&manifest).unwrap();
+        let err = remote.validate().unwrap_err();
+        assert!(err.to_string().contains("Unresolved placeholder"));
+    }
+
+    #[test]
     fn test_remote_manifest_override_namespace_defaults_to_false() {
         let manifest = json!({
             "apiVersion": "nyl.niklasrosenstein.github.com/v1",
@@ -154,5 +340,77 @@ mod tests {
         });
         let err = RemoteManifest::from_value(&manifest).unwrap_err();
         assert!(err.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn test_apply_params_substitutes_placeholders() {
+        let params = HashMap::from([("version".to_string(), "1.5.1".to_string())]);
+        let result = RemoteManifest::apply_params(
+            "https://example.com/v{version}/crds.yaml",
+            &params,
+        )
+        .unwrap();
+        assert_eq!(result, "https://example.com/v1.5.1/crds.yaml");
+    }
+
+    #[test]
+    fn test_apply_params_multiple_substitutions() {
+        let params = HashMap::from([
+            ("version".to_string(), "1.5.1".to_string()),
+            ("name".to_string(), "gatewayclasses".to_string()),
+        ]);
+        let result = RemoteManifest::apply_params(
+            "https://example.com/v{version}/{name}.yaml",
+            &params,
+        )
+        .unwrap();
+        assert_eq!(result, "https://example.com/v1.5.1/gatewayclasses.yaml");
+    }
+
+    #[test]
+    fn test_apply_params_rejects_unresolved_placeholder() {
+        let params = HashMap::from([("version".to_string(), "1.5.1".to_string())]);
+        let err = RemoteManifest::apply_params(
+            "https://example.com/v{version}/{unknown}.yaml",
+            &params,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("Unresolved placeholder"));
+        assert!(err.to_string().contains("{unknown}"));
+    }
+
+    #[test]
+    fn test_resolve_urls_from_url() {
+        let manifest = json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "remote"},
+            "spec": {"url": "https://example.com/manifests.yaml"}
+        });
+        let remote = RemoteManifest::from_value(&manifest).unwrap();
+        let urls = remote.resolve_urls().unwrap();
+        assert_eq!(urls, vec!["https://example.com/manifests.yaml"]);
+    }
+
+    #[test]
+    fn test_resolve_urls_from_sources_with_params() {
+        let manifest = json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "remote"},
+            "spec": {
+                "params": {"version": "1.5.1"},
+                "sources": [
+                    "https://example.com/v{version}/a.yaml",
+                    "https://example.com/v{version}/b.yaml"
+                ]
+            }
+        });
+        let remote = RemoteManifest::from_value(&manifest).unwrap();
+        let urls = remote.resolve_urls().unwrap();
+        assert_eq!(urls, vec![
+            "https://example.com/v1.5.1/a.yaml",
+            "https://example.com/v1.5.1/b.yaml",
+        ]);
     }
 }

--- a/nyl/src/resources/remote_manifest.rs
+++ b/nyl/src/resources/remote_manifest.rs
@@ -14,13 +14,13 @@ use crate::{NylError, Result};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RemoteManifestSpec {
-    /// Single HTTPS URL to fetch (mutually exclusive with `sources`)
+    /// Single HTTPS URL to fetch (mutually exclusive with `urls`)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
     /// List of HTTPS URL templates to fetch (mutually exclusive with `url`)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sources: Option<Vec<String>>,
-    /// Parameters for `{key}` substitution in `sources` URL templates
+    pub urls: Option<Vec<String>>,
+    /// Parameters for `{key}` substitution in `urls` URL templates
     #[serde(skip_serializing_if = "Option::is_none")]
     pub params: Option<HashMap<String, String>>,
     /// Overwrite fetched manifest metadata.namespace with RemoteManifest metadata.namespace
@@ -58,21 +58,21 @@ impl RemoteManifest {
 
     /// Validate the RemoteManifest configuration
     pub fn validate(&self) -> Result<()> {
-        match (&self.spec.url, &self.spec.sources) {
+        match (&self.spec.url, &self.spec.urls) {
             (Some(_), Some(_)) => {
                 return Err(NylError::Config(
-                    "RemoteManifest spec.url and spec.sources are mutually exclusive".to_string(),
+                    "RemoteManifest spec.url and spec.urls are mutually exclusive".to_string(),
                 ))
             }
             (None, None) => {
                 return Err(NylError::Config(
-                    "RemoteManifest must specify either spec.url or spec.sources".to_string(),
+                    "RemoteManifest must specify either spec.url or spec.urls".to_string(),
                 ))
             }
             (Some(url), None) => {
                 if self.spec.params.is_some() {
                     return Err(NylError::Config(
-                        "RemoteManifest spec.params requires spec.sources".to_string(),
+                        "RemoteManifest spec.params requires spec.urls".to_string(),
                     ));
                 }
                 let url = url.trim();
@@ -87,20 +87,21 @@ impl RemoteManifest {
                     )));
                 }
             }
-            (None, Some(sources)) => {
-                if sources.is_empty() {
+            (None, Some(urls)) => {
+                if urls.is_empty() {
                     return Err(NylError::Config(
-                        "RemoteManifest spec.sources must not be empty".to_string(),
+                        "RemoteManifest spec.urls must not be empty".to_string(),
                     ));
                 }
-                for source in sources {
+                for url in urls {
+                    let trimmed = url.trim();
                     let resolved = match &self.spec.params {
-                        Some(params) => Self::apply_params(source, params)?,
-                        None => source.clone(),
+                        Some(params) => Self::apply_params(trimmed, params)?,
+                        None => trimmed.to_string(),
                     };
-                    if !resolved.trim().starts_with("https://") {
+                    if !resolved.starts_with("https://") {
                         return Err(NylError::Config(format!(
-                            "RemoteManifest spec.sources entry must use https:// scheme, got '{source}'"
+                            "RemoteManifest spec.urls entry must use https:// scheme, got '{url}'"
                         )));
                     }
                 }
@@ -122,26 +123,31 @@ impl RemoteManifest {
                     "Unresolved placeholder '{placeholder}' in RemoteManifest URL template '{template}'"
                 )));
             }
+            return Err(NylError::Config(format!(
+                "Malformed placeholder (unclosed '{{') in RemoteManifest URL template '{template}'"
+            )));
         }
         Ok(result)
     }
 
     /// Resolve the list of concrete HTTPS URLs to fetch.
+    ///
+    /// Callers must invoke `validate()` before calling this method.
     pub fn resolve_urls(&self) -> Result<Vec<String>> {
         if let Some(url) = &self.spec.url {
             Ok(vec![url.trim().to_string()])
-        } else if let Some(sources) = &self.spec.sources {
-            sources
-                .iter()
-                .map(|s| match &self.spec.params {
-                    Some(params) => Self::apply_params(s, params),
-                    None => Ok(s.clone()),
+        } else if let Some(urls) = &self.spec.urls {
+            urls.iter()
+                .map(|s| {
+                    let trimmed = s.trim();
+                    match &self.spec.params {
+                        Some(params) => Self::apply_params(trimmed, params),
+                        None => Ok(trimmed.to_string()),
+                    }
                 })
                 .collect()
         } else {
-            Err(NylError::Config(
-                "RemoteManifest must specify either spec.url or spec.sources".to_string(),
-            ))
+            unreachable!("resolve_urls called on unvalidated RemoteManifest (neither url nor urls set)")
         }
     }
 }
@@ -199,7 +205,7 @@ mod tests {
     }
 
     #[test]
-    fn test_remote_manifest_validate_rejects_neither_url_nor_sources() {
+    fn test_remote_manifest_validate_rejects_neither_url_nor_urls() {
         let manifest = json!({
             "apiVersion": "nyl.niklasrosenstein.github.com/v1",
             "kind": "RemoteManifest",
@@ -208,18 +214,18 @@ mod tests {
         });
         let remote = RemoteManifest::from_value(&manifest).unwrap();
         let err = remote.validate().unwrap_err();
-        assert!(err.to_string().contains("spec.url or spec.sources"));
+        assert!(err.to_string().contains("spec.url or spec.urls"));
     }
 
     #[test]
-    fn test_remote_manifest_validate_rejects_both_url_and_sources() {
+    fn test_remote_manifest_validate_rejects_both_url_and_urls() {
         let manifest = json!({
             "apiVersion": "nyl.niklasrosenstein.github.com/v1",
             "kind": "RemoteManifest",
             "metadata": {"name": "remote"},
             "spec": {
                 "url": "https://example.com/a.yaml",
-                "sources": ["https://example.com/b.yaml"]
+                "urls": ["https://example.com/b.yaml"]
             }
         });
         let remote = RemoteManifest::from_value(&manifest).unwrap();
@@ -228,7 +234,7 @@ mod tests {
     }
 
     #[test]
-    fn test_remote_manifest_validate_rejects_params_without_sources() {
+    fn test_remote_manifest_validate_rejects_params_without_urls() {
         let manifest = json!({
             "apiVersion": "nyl.niklasrosenstein.github.com/v1",
             "kind": "RemoteManifest",
@@ -240,29 +246,29 @@ mod tests {
         });
         let remote = RemoteManifest::from_value(&manifest).unwrap();
         let err = remote.validate().unwrap_err();
-        assert!(err.to_string().contains("spec.params requires spec.sources"));
+        assert!(err.to_string().contains("spec.params requires spec.urls"));
     }
 
     #[test]
-    fn test_remote_manifest_validate_rejects_empty_sources() {
+    fn test_remote_manifest_validate_rejects_empty_urls() {
         let manifest = json!({
             "apiVersion": "nyl.niklasrosenstein.github.com/v1",
             "kind": "RemoteManifest",
             "metadata": {"name": "remote"},
-            "spec": {"sources": []}
+            "spec": {"urls": []}
         });
         let remote = RemoteManifest::from_value(&manifest).unwrap();
         let err = remote.validate().unwrap_err();
-        assert!(err.to_string().contains("spec.sources must not be empty"));
+        assert!(err.to_string().contains("spec.urls must not be empty"));
     }
 
     #[test]
-    fn test_remote_manifest_validate_rejects_non_https_in_sources() {
+    fn test_remote_manifest_validate_rejects_non_https_in_urls() {
         let manifest = json!({
             "apiVersion": "nyl.niklasrosenstein.github.com/v1",
             "kind": "RemoteManifest",
             "metadata": {"name": "remote"},
-            "spec": {"sources": ["https://example.com/a.yaml", "http://example.com/b.yaml"]}
+            "spec": {"urls": ["https://example.com/a.yaml", "http://example.com/b.yaml"]}
         });
         let remote = RemoteManifest::from_value(&manifest).unwrap();
         let err = remote.validate().unwrap_err();
@@ -270,14 +276,14 @@ mod tests {
     }
 
     #[test]
-    fn test_remote_manifest_validate_accepts_sources_with_params() {
+    fn test_remote_manifest_validate_accepts_urls_with_params() {
         let manifest = json!({
             "apiVersion": "nyl.niklasrosenstein.github.com/v1",
             "kind": "RemoteManifest",
             "metadata": {"name": "remote"},
             "spec": {
                 "params": {"version": "1.5.1"},
-                "sources": [
+                "urls": [
                     "https://example.com/v{version}/a.yaml",
                     "https://example.com/v{version}/b.yaml"
                 ]
@@ -288,14 +294,14 @@ mod tests {
     }
 
     #[test]
-    fn test_remote_manifest_validate_rejects_unresolved_placeholder_in_sources() {
+    fn test_remote_manifest_validate_rejects_unresolved_placeholder_in_urls() {
         let manifest = json!({
             "apiVersion": "nyl.niklasrosenstein.github.com/v1",
             "kind": "RemoteManifest",
             "metadata": {"name": "remote"},
             "spec": {
                 "params": {"version": "1.5.1"},
-                "sources": ["https://example.com/{version}/{unknown}/a.yaml"]
+                "urls": ["https://example.com/{version}/{unknown}/a.yaml"]
             }
         });
         let remote = RemoteManifest::from_value(&manifest).unwrap();
@@ -380,6 +386,17 @@ mod tests {
     }
 
     #[test]
+    fn test_apply_params_rejects_unclosed_brace() {
+        let params = HashMap::from([("version".to_string(), "1.5.1".to_string())]);
+        let err = RemoteManifest::apply_params(
+            "https://example.com/v{version}/{unclosed",
+            &params,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("Malformed placeholder"));
+    }
+
+    #[test]
     fn test_resolve_urls_from_url() {
         let manifest = json!({
             "apiVersion": "nyl.niklasrosenstein.github.com/v1",
@@ -393,14 +410,30 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_urls_from_sources_with_params() {
+    fn test_resolve_urls_trims_whitespace() {
+        let manifest = json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "remote"},
+            "spec": {"urls": ["  https://example.com/a.yaml  ", " https://example.com/b.yaml "]}
+        });
+        let remote = RemoteManifest::from_value(&manifest).unwrap();
+        let urls = remote.resolve_urls().unwrap();
+        assert_eq!(urls, vec![
+            "https://example.com/a.yaml",
+            "https://example.com/b.yaml",
+        ]);
+    }
+
+    #[test]
+    fn test_resolve_urls_from_urls_with_params() {
         let manifest = json!({
             "apiVersion": "nyl.niklasrosenstein.github.com/v1",
             "kind": "RemoteManifest",
             "metadata": {"name": "remote"},
             "spec": {
                 "params": {"version": "1.5.1"},
-                "sources": [
+                "urls": [
                     "https://example.com/v{version}/a.yaml",
                     "https://example.com/v{version}/b.yaml"
                 ]

--- a/nyl/src/resources/remote_manifest.rs
+++ b/nyl/src/resources/remote_manifest.rs
@@ -93,6 +93,15 @@ impl RemoteManifest {
                         "RemoteManifest spec.urls must not be empty".to_string(),
                     ));
                 }
+                if let Some(params) = &self.spec.params {
+                    for (key, value) in params {
+                        if value.contains('{') || value.contains('}') {
+                            return Err(NylError::Config(format!(
+                                "RemoteManifest spec.params value for '{key}' must not contain '{{' or '}}' characters"
+                            )));
+                        }
+                    }
+                }
                 for url in urls {
                     let trimmed = url.trim();
                     let resolved = match &self.spec.params {
@@ -101,7 +110,7 @@ impl RemoteManifest {
                     };
                     if !resolved.starts_with("https://") {
                         return Err(NylError::Config(format!(
-                            "RemoteManifest spec.urls entry must use https:// scheme, got '{url}'"
+                            "RemoteManifest spec.urls entry must use https:// scheme, got '{resolved}' (from template '{url}')"
                         )));
                     }
                 }
@@ -125,6 +134,11 @@ impl RemoteManifest {
             }
             return Err(NylError::Config(format!(
                 "Malformed placeholder (unclosed '{{') in RemoteManifest URL template '{template}'"
+            )));
+        }
+        if result.contains('}') {
+            return Err(NylError::Config(format!(
+                "Malformed placeholder (unmatched '}}') in RemoteManifest URL template '{template}'"
             )));
         }
         Ok(result)
@@ -351,11 +365,7 @@ mod tests {
     #[test]
     fn test_apply_params_substitutes_placeholders() {
         let params = HashMap::from([("version".to_string(), "1.5.1".to_string())]);
-        let result = RemoteManifest::apply_params(
-            "https://example.com/v{version}/crds.yaml",
-            &params,
-        )
-        .unwrap();
+        let result = RemoteManifest::apply_params("https://example.com/v{version}/crds.yaml", &params).unwrap();
         assert_eq!(result, "https://example.com/v1.5.1/crds.yaml");
     }
 
@@ -365,22 +375,14 @@ mod tests {
             ("version".to_string(), "1.5.1".to_string()),
             ("name".to_string(), "gatewayclasses".to_string()),
         ]);
-        let result = RemoteManifest::apply_params(
-            "https://example.com/v{version}/{name}.yaml",
-            &params,
-        )
-        .unwrap();
+        let result = RemoteManifest::apply_params("https://example.com/v{version}/{name}.yaml", &params).unwrap();
         assert_eq!(result, "https://example.com/v1.5.1/gatewayclasses.yaml");
     }
 
     #[test]
     fn test_apply_params_rejects_unresolved_placeholder() {
         let params = HashMap::from([("version".to_string(), "1.5.1".to_string())]);
-        let err = RemoteManifest::apply_params(
-            "https://example.com/v{version}/{unknown}.yaml",
-            &params,
-        )
-        .unwrap_err();
+        let err = RemoteManifest::apply_params("https://example.com/v{version}/{unknown}.yaml", &params).unwrap_err();
         assert!(err.to_string().contains("Unresolved placeholder"));
         assert!(err.to_string().contains("{unknown}"));
     }
@@ -388,12 +390,31 @@ mod tests {
     #[test]
     fn test_apply_params_rejects_unclosed_brace() {
         let params = HashMap::from([("version".to_string(), "1.5.1".to_string())]);
-        let err = RemoteManifest::apply_params(
-            "https://example.com/v{version}/{unclosed",
-            &params,
-        )
-        .unwrap_err();
+        let err = RemoteManifest::apply_params("https://example.com/v{version}/{unclosed", &params).unwrap_err();
         assert!(err.to_string().contains("Malformed placeholder"));
+    }
+
+    #[test]
+    fn test_apply_params_rejects_stray_closing_brace() {
+        let params = HashMap::from([("version".to_string(), "1.5.1".to_string())]);
+        let err = RemoteManifest::apply_params("https://example.com/v{version}/stray}brace", &params).unwrap_err();
+        assert!(err.to_string().contains("Malformed placeholder"));
+    }
+
+    #[test]
+    fn test_validate_rejects_params_value_with_braces() {
+        let manifest = json!({
+            "apiVersion": "nyl.niklasrosenstein.github.com/v1",
+            "kind": "RemoteManifest",
+            "metadata": {"name": "remote"},
+            "spec": {
+                "params": {"version": "1.5.1", "path": "{version}/sub"},
+                "urls": ["https://example.com/{version}/{path}.yaml"]
+            }
+        });
+        let remote = RemoteManifest::from_value(&manifest).unwrap();
+        let err = remote.validate().unwrap_err();
+        assert!(err.to_string().contains("must not contain"));
     }
 
     #[test]
@@ -419,10 +440,7 @@ mod tests {
         });
         let remote = RemoteManifest::from_value(&manifest).unwrap();
         let urls = remote.resolve_urls().unwrap();
-        assert_eq!(urls, vec![
-            "https://example.com/a.yaml",
-            "https://example.com/b.yaml",
-        ]);
+        assert_eq!(urls, vec!["https://example.com/a.yaml", "https://example.com/b.yaml",]);
     }
 
     #[test]
@@ -441,9 +459,9 @@ mod tests {
         });
         let remote = RemoteManifest::from_value(&manifest).unwrap();
         let urls = remote.resolve_urls().unwrap();
-        assert_eq!(urls, vec![
-            "https://example.com/v1.5.1/a.yaml",
-            "https://example.com/v1.5.1/b.yaml",
-        ]);
+        assert_eq!(
+            urls,
+            vec!["https://example.com/v1.5.1/a.yaml", "https://example.com/v1.5.1/b.yaml",]
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add `spec.urls` (list of HTTPS URL templates) as an alternative to `spec.url` for fetching from multiple URLs in a single `RemoteManifest`
- Add `spec.params` (string key→value map) for `{key}` placeholder substitution in `spec.urls` entries — useful for pinning a shared version across many CRD files
- Documents from all URLs are fetched sequentially and concatenated; `overrideNamespace` is applied once across the full set
- `spec.url` and `spec.urls` are mutually exclusive; `spec.params` requires `spec.urls`; unresolved `{placeholders}` and unclosed `{` are caught at validation time

## Test plan

- [x] All existing `remote_manifest` unit tests still pass (backward-compatible `spec.url` path unchanged)
- [x] New unit tests cover: mutual exclusivity, empty urls, non-HTTPS in urls, `params` without `urls`, unresolved placeholders, unclosed `{` in templates, whitespace trimming, `apply_params` substitution, `resolve_urls` with params
- [x] `test_generate_resource_remote_manifest_rejects_http_url` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)