### PR TITLE
Fix and exercise ArgoCD bootstrap E2E

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -304,8 +304,10 @@ jobs:
 
   integration-minikube:
     name: Integration tests (Minikube)
-    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
-    needs: [package-image-and-chart, build-all-platform-binaries]
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
+    needs: [package-image-and-chart]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -372,7 +372,22 @@ jobs:
           cd integrationtests
           ./test-argocd-bootstrap.sh
 
+      - name: Check ArgoCD credential test configuration
+        id: credential_test
+        env:
+          TEST_REPO_URL: ${{ secrets.TEST_REPO_URL }}
+          TEST_REPO_USERNAME: ${{ secrets.TEST_REPO_USERNAME }}
+          TEST_REPO_PASSWORD: ${{ secrets.TEST_REPO_PASSWORD }}
+        run: |
+          if [ -n "$TEST_REPO_URL" ] && [ -n "$TEST_REPO_USERNAME" ] && [ -n "$TEST_REPO_PASSWORD" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping ArgoCD credential lookup test because its repository credentials are not configured."
+          fi
+
       - name: Run ArgoCD credential lookup test
+        if: steps.credential_test.outputs.enabled == 'true'
         env:
           NYL_BIN: /usr/local/bin/nyl
           TEST_REPO_URL: ${{ secrets.TEST_REPO_URL }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,8 +70,13 @@ jobs:
         working-directory: nyl
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        run: cargo binstall cargo-audit --no-confirm --disable-strategies compile --only-signed --disable-telemetry
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Security audit
         run: cargo audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/examples/argocd-bootstrap/bootstrap.yaml
+++ b/examples/argocd-bootstrap/bootstrap.yaml
@@ -45,6 +45,8 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
 ---
 # Create the argocd namespace
 apiVersion: v1

--- a/examples/argocd-bootstrap/bootstrap.yaml
+++ b/examples/argocd-bootstrap/bootstrap.yaml
@@ -38,6 +38,8 @@ spec:
       NYL_CHART_OWNER: "{{ env.NYL_CHART_OWNER | default('niklasrosenstein') }}"
       NYL_CHART_VERSION: "{{ env.NYL_CHART_VERSION | default('0.1.0') }}"
       NYL_IMAGE_TAG: "{{ env.NYL_IMAGE_TAG | default('develop') }}"
+      NYL_REPO_URL: "{{ env.NYL_REPO_URL }}"
+      NYL_TARGET_REVISION: "{{ env.NYL_TARGET_REVISION | default('HEAD') }}"
   project: default
   syncPolicy:
     automated:

--- a/examples/argocd-bootstrap/bootstrap.yaml
+++ b/examples/argocd-bootstrap/bootstrap.yaml
@@ -34,6 +34,10 @@ spec:
     repoURL: "{{ env.NYL_REPO_URL }}"
     targetRevision: "{{ env.NYL_TARGET_REVISION | default('HEAD') }}"
     path: examples/argocd-bootstrap
+    pluginEnv:
+      NYL_CHART_OWNER: "{{ env.NYL_CHART_OWNER | default('niklasrosenstein') }}"
+      NYL_CHART_VERSION: "{{ env.NYL_CHART_VERSION | default('0.1.0') }}"
+      NYL_IMAGE_TAG: "{{ env.NYL_IMAGE_TAG | default('develop') }}"
   project: default
   syncPolicy:
     automated:

--- a/integrationtests/test-argocd-bootstrap.sh
+++ b/integrationtests/test-argocd-bootstrap.sh
@@ -343,14 +343,75 @@ echo "✓ Self-managed application 'argocd' found"
 echo ""
 
 echo "Syncing ArgoCD application..."
-if ! argocd app sync argocd --timeout "${SYNC_TIMEOUT}"; then
-    echo "ERROR: Sync failed"
+if ! argocd app sync argocd --async; then
+    echo "ERROR: Failed to request sync"
     echo ""
     argocd app get argocd --show-operation
     exit 1
 fi
 
+echo "Waiting for the sync operation through the Kubernetes API..."
+SYNC_START=${SECONDS}
+SYNC_PHASE=""
+while (( SECONDS - SYNC_START < SYNC_TIMEOUT )); do
+    SYNC_PHASE=$(kubectl get application argocd -n "${NAMESPACE}" \
+        -o jsonpath='{.status.operationState.phase}' 2>/dev/null || true)
+    case "${SYNC_PHASE}" in
+        Succeeded)
+            break
+            ;;
+        Error|Failed)
+            echo "ERROR: Sync operation finished with phase ${SYNC_PHASE}"
+            kubectl get application argocd -n "${NAMESPACE}" -o yaml
+            exit 1
+            ;;
+    esac
+    sleep 5
+done
+
+if [ "${SYNC_PHASE}" != "Succeeded" ]; then
+    echo "ERROR: Sync operation did not succeed within ${SYNC_TIMEOUT}s (phase: ${SYNC_PHASE:-unset})"
+    kubectl get application argocd -n "${NAMESPACE}" -o yaml
+    exit 1
+fi
+
 echo "✓ Application synced"
+echo ""
+
+# Self-management can restart ArgoCD while applying its own Deployment.
+kill "${PORT_FORWARD_PID}" 2>/dev/null || true
+wait "${PORT_FORWARD_PID}" 2>/dev/null || true
+unset PORT_FORWARD_PID
+
+echo "Waiting for ArgoCD deployments after self-sync..."
+for deployment in argocd-server argocd-repo-server; do
+    kubectl rollout status deployment/${deployment} -n "${NAMESPACE}" \
+        --timeout="${DEPLOYMENT_TIMEOUT}s"
+done
+
+echo "Reconnecting to ArgoCD..."
+kubectl port-forward svc/argocd-server -n "${NAMESPACE}" 8080:443 &>/dev/null &
+PORT_FORWARD_PID=$!
+
+ARGOCD_RECONNECTED=false
+for i in $(seq 1 30); do
+    if argocd login localhost:8080 \
+        --username admin \
+        --password "${PASSWORD}" \
+        --insecure &>/dev/null; then
+        ARGOCD_RECONNECTED=true
+        break
+    fi
+    echo "  Reconnect attempt $i/30..."
+    sleep 2
+done
+
+if [ "${ARGOCD_RECONNECTED}" != "true" ]; then
+    echo "ERROR: Could not reconnect to ArgoCD after self-sync"
+    exit 1
+fi
+
+echo "✓ Reconnected to ArgoCD"
 echo ""
 
 echo "Waiting for healthy status..."

--- a/integrationtests/test-argocd-bootstrap.sh
+++ b/integrationtests/test-argocd-bootstrap.sh
@@ -239,20 +239,20 @@ kubectl get pod "${REPO_POD}" -n "${NAMESPACE}" \
 echo ""
 
 NYL_READY=$(kubectl get pod "${REPO_POD}" -n "${NAMESPACE}" \
-    -o jsonpath='{.status.containerStatuses[?(@.name=="nyl-v1")].ready}')
+    -o jsonpath='{.status.containerStatuses[?(@.name=="nyl-v2")].ready}')
 
 if [ "${NYL_READY}" != "true" ]; then
-    echo "ERROR: nyl-v1 sidecar not ready"
+    echo "ERROR: nyl-v2 sidecar not ready"
     echo ""
     echo "Pod details:"
     kubectl describe pod "${REPO_POD}" -n "${NAMESPACE}"
     echo ""
     echo "Nyl sidecar logs:"
-    kubectl logs "${REPO_POD}" -n "${NAMESPACE}" -c nyl-v1 --tail=50 || true
+    kubectl logs "${REPO_POD}" -n "${NAMESPACE}" -c nyl-v2 --tail=50 || true
     exit 1
 fi
 
-echo "✓ nyl-v1 sidecar is ready"
+echo "✓ nyl-v2 sidecar is ready"
 echo ""
 
 # Install ArgoCD CLI if not already installed

--- a/nyl/book/src/content/docs/argocd/application-generator.md
+++ b/nyl/book/src/content/docs/argocd/application-generator.md
@@ -25,6 +25,8 @@ spec:
     paths: [string]         # Multiple selectors to scan (mutually exclusive with path)
     include: [string]       # Include patterns (default: ["*.yaml", "*.yml"])
     exclude: [string]       # Exclude patterns (default: [".*", "_*", ".nyl/**"])
+    pluginEnv:              # Environment variables for generated CMP Applications
+      NAME: value
   project: string           # ArgoCD project (default: "default")
   syncPolicy:               # Optional sync policy for generated Applications
     automated:
@@ -92,6 +94,11 @@ Configures the Git repository and directory scanning behavior.
   - Takes precedence over include patterns
   - Default excludes hidden files (`.`), underscore-prefixed files (`_`), and Nyl cache directories
   - Example: `["test_*", ".*", "backup*"]`
+
+- **pluginEnv** (optional): Environment variables passed to the Nyl CMP plugin in every generated Application
+  - Values are strings and keys are emitted in sorted order
+  - `NYL_RELEASE_NAME`, `NYL_RELEASE_NAMESPACE`, and `NYL_CMP_TEMPLATE_INPUT` are reserved
+  - Project-level configuration can use this field to provide inputs required while ArgoCD renders an Application
 
 ### spec.project
 

--- a/nyl/book/src/content/docs/argocd/application-generator.md
+++ b/nyl/book/src/content/docs/argocd/application-generator.md
@@ -97,6 +97,7 @@ Configures the Git repository and directory scanning behavior.
 
 - **pluginEnv** (optional): Environment variables passed to the Nyl CMP plugin in every generated Application
   - Values are strings and keys are emitted in sorted order
+  - ArgoCD's `ARGOCD_ENV_` prefix is normalized, so a `NYL_REGION` entry is available to templates as `env.NYL_REGION`
   - `NYL_RELEASE_NAME`, `NYL_RELEASE_NAMESPACE`, and `NYL_CMP_TEMPLATE_INPUT` are reserved
   - Project-level configuration can use this field to provide inputs required while ArgoCD renders an Application
 

--- a/nyl/src/cli/commands/render.rs
+++ b/nyl/src/cli/commands/render.rs
@@ -2051,6 +2051,20 @@ fn create_argocd_application_from_generator(
         rel_dir_normalized
     };
 
+    let mut plugin_env = vec![
+        serde_json::json!({"name": "NYL_RELEASE_NAME", "value": release.metadata.name}),
+        serde_json::json!({"name": "NYL_RELEASE_NAMESPACE", "value": release.metadata.namespace}),
+        serde_json::json!({"name": "NYL_CMP_TEMPLATE_INPUT", "value": template_input}),
+    ];
+    plugin_env.extend(
+        generator
+            .spec
+            .source
+            .plugin_env
+            .iter()
+            .map(|(name, value)| serde_json::json!({"name": name, "value": value})),
+    );
+
     // Build the Application manifest
     let mut app = serde_json::json!({
         "apiVersion": "argoproj.io/v1alpha1",
@@ -2067,11 +2081,7 @@ fn create_argocd_application_from_generator(
                 "targetRevision": generator.spec.source.target_revision,
                 "plugin": {
                     "name": "nyl-v2",
-                    "env": [
-                        {"name": "NYL_RELEASE_NAME", "value": release.metadata.name},
-                        {"name": "NYL_RELEASE_NAMESPACE", "value": release.metadata.namespace},
-                        {"name": "NYL_CMP_TEMPLATE_INPUT", "value": template_input},
-                    ],
+                    "env": plugin_env,
                 },
             },
             "destination": {
@@ -2635,6 +2645,7 @@ mod tests {
                     paths: None,
                     include: vec!["*.yaml".to_string()],
                     exclude: vec![".*".to_string()],
+                    plugin_env: std::collections::BTreeMap::default(),
                 },
                 project: "default".to_string(),
                 sync_policy,
@@ -2699,6 +2710,7 @@ mod tests {
                     paths: None,
                     include: vec!["*.yaml".to_string()],
                     exclude: vec![".*".to_string()],
+                    plugin_env: std::collections::BTreeMap::default(),
                 },
                 project: "default".to_string(),
                 sync_policy: None,
@@ -2758,6 +2770,7 @@ mod tests {
                     paths: None,
                     include: vec!["*.yaml".to_string()],
                     exclude: vec![".*".to_string()],
+                    plugin_env: std::collections::BTreeMap::default(),
                 },
                 project: "default".to_string(),
                 sync_policy: None,
@@ -2910,12 +2923,12 @@ metadata:
     }
 
     #[test]
-    fn test_create_argocd_application_from_generator_sets_template_input() {
+    fn test_create_argocd_application_from_generator_sets_plugin_env() {
         use crate::resources::{
             ApplicationDestination, ApplicationGenerator, ApplicationGeneratorMetadata, ApplicationGeneratorSpec,
             ApplicationSource, NylReleaseMetadata, NylReleaseSpec,
         };
-        use std::collections::HashMap;
+        use std::collections::{BTreeMap, HashMap};
 
         let release = NylRelease {
             api_version: API_VERSION.to_string(),
@@ -2946,6 +2959,10 @@ metadata:
                     paths: None,
                     include: vec!["*.yaml".to_string()],
                     exclude: vec![".*".to_string()],
+                    plugin_env: BTreeMap::from([
+                        ("ENVIRONMENT".to_string(), "production".to_string()),
+                        ("REGION".to_string(), "eu-central-1".to_string()),
+                    ]),
                 },
                 project: "default".to_string(),
                 sync_policy: None,
@@ -2969,6 +2986,18 @@ metadata:
             .and_then(|v| v["value"].as_str())
             .unwrap();
         assert_eq!(template_input, "nginx.yaml");
+        assert_eq!(
+            env.iter()
+                .find(|v| v["name"] == "ENVIRONMENT")
+                .and_then(|v| v["value"].as_str()),
+            Some("production")
+        );
+        assert_eq!(
+            env.iter()
+                .find(|v| v["name"] == "REGION")
+                .and_then(|v| v["value"].as_str()),
+            Some("eu-central-1")
+        );
     }
 
     fn make_test_release(override_map: serde_json::Value) -> NylRelease {
@@ -3009,6 +3038,7 @@ metadata:
                     paths: None,
                     include: vec!["*.yaml".to_string()],
                     exclude: vec![".*".to_string()],
+                    plugin_env: std::collections::BTreeMap::default(),
                 },
                 project: "default".to_string(),
                 sync_policy: None,
@@ -3336,6 +3366,7 @@ metadata:
                     paths: None,
                     include: vec!["*.yaml".to_string()],
                     exclude: vec![".*".to_string()],
+                    plugin_env: std::collections::BTreeMap::default(),
                 },
                 project: "default".to_string(),
                 sync_policy: None,
@@ -3494,6 +3525,7 @@ metadata:
                     paths: None,
                     include: vec!["*.yaml".to_string()],
                     exclude: vec![".*".to_string()],
+                    plugin_env: std::collections::BTreeMap::default(),
                 },
                 project: "default".to_string(),
                 sync_policy: None,
@@ -3542,6 +3574,7 @@ metadata:
                     paths: None,
                     include: vec!["*.yaml".to_string()],
                     exclude: vec![".*".to_string()],
+                    plugin_env: std::collections::BTreeMap::default(),
                 },
                 project: "default".to_string(),
                 sync_policy: None,
@@ -3618,6 +3651,7 @@ metadata:
                     paths: None,
                     include: vec!["*.yaml".to_string()],
                     exclude: vec![".*".to_string()],
+                    plugin_env: std::collections::BTreeMap::default(),
                 },
                 project: "default".to_string(),
                 sync_policy: None,

--- a/nyl/src/resources/application_generator.rs
+++ b/nyl/src/resources/application_generator.rs
@@ -4,7 +4,7 @@
 /// from Nyl YAML files by scanning directories and creating Applications for
 /// each discovered NylRelease.
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::constants::API_VERSION_ARGOCD;
 use crate::resources::validate_path_glob_pattern;
@@ -104,6 +104,9 @@ pub struct ApplicationSource {
     /// Exclude patterns for file filtering
     #[serde(default = "default_exclude")]
     pub exclude: Vec<String>,
+    /// Environment variables passed to the Nyl CMP plugin in generated Applications
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty", rename = "pluginEnv")]
+    pub plugin_env: BTreeMap<String, String>,
 }
 
 /// ArgoCD sync policy
@@ -199,6 +202,21 @@ impl ApplicationGenerator {
         }
         if self.spec.destination.namespace.is_empty() {
             return Err(NylError::Config("spec.destination.namespace is required".to_string()));
+        }
+        for name in self.spec.source.plugin_env.keys() {
+            if name.trim().is_empty() {
+                return Err(NylError::Config(
+                    "spec.source.pluginEnv variable names must not be empty".to_string(),
+                ));
+            }
+            if matches!(
+                name.as_str(),
+                "NYL_RELEASE_NAME" | "NYL_RELEASE_NAMESPACE" | "NYL_CMP_TEMPLATE_INPUT"
+            ) {
+                return Err(NylError::Config(format!(
+                    "spec.source.pluginEnv cannot override reserved variable {name}"
+                )));
+            }
         }
         if let Some(customization) = &self.spec.release_customization {
             let patterns = customization.effective_allowed_paths();
@@ -357,7 +375,10 @@ mod tests {
                     "targetRevision": "main",
                     "path": "clusters/default",
                     "include": ["*.yaml"],
-                    "exclude": ["test_*"]
+                    "exclude": ["test_*"],
+                    "pluginEnv": {
+                        "ENVIRONMENT": "production"
+                    }
                 },
                 "project": "production",
                 "syncPolicy": {
@@ -378,6 +399,10 @@ mod tests {
         assert_eq!(gen.spec.source.target_revision, "main");
         assert_eq!(gen.spec.source.include, vec!["*.yaml"]);
         assert_eq!(gen.spec.source.exclude, vec!["test_*"]);
+        assert_eq!(
+            gen.spec.source.plugin_env.get("ENVIRONMENT").map(String::as_str),
+            Some("production")
+        );
         assert_eq!(
             gen.spec.application_name_template,
             "{{ .release.namespace }}-{{ .release.name }}"
@@ -430,6 +455,7 @@ mod tests {
                     paths: None,
                     include: vec!["*.yaml".to_string()],
                     exclude: vec![".*".to_string()],
+                    plugin_env: std::collections::BTreeMap::default(),
                 },
                 project: "default".to_string(),
                 sync_policy: None,
@@ -441,6 +467,19 @@ mod tests {
         };
 
         assert!(gen.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_rejects_reserved_plugin_env_variable() {
+        let mut generator = create_test_generator();
+        generator
+            .spec
+            .source
+            .plugin_env
+            .insert("NYL_CMP_TEMPLATE_INPUT".to_string(), "another-file.yaml".to_string());
+
+        let error = generator.validate().unwrap_err().to_string();
+        assert!(error.contains("cannot override reserved variable NYL_CMP_TEMPLATE_INPUT"));
     }
 
     #[test]
@@ -692,6 +731,7 @@ mod tests {
                     paths: None,
                     include: vec!["*.yaml".to_string()],
                     exclude: vec![".*".to_string()],
+                    plugin_env: std::collections::BTreeMap::default(),
                 },
                 project: "default".to_string(),
                 sync_policy: None,

--- a/nyl/src/template/mod.rs
+++ b/nyl/src/template/mod.rs
@@ -82,16 +82,33 @@ impl TemplateContext {
         })
     }
 
-    /// Filter environment variables to only include NYL_ prefixed ones.
+    /// Filter environment variables to only include Nyl inputs.
     ///
     /// This prevents accidental leakage of sensitive CI/runtime secrets into manifests.
+    /// ArgoCD prefixes plugin parameters with `ARGOCD_ENV_`; Nyl exposes their
+    /// `NYL_` names so the same template works locally and in the CMP sidecar.
     fn filter_env_vars<I>(vars: I) -> serde_json::Map<String, serde_json::Value>
     where
         I: Iterator<Item = (String, String)>,
     {
-        vars.filter(|(k, _)| k.starts_with("NYL_"))
-            .map(|(k, v)| (k, serde_json::Value::String(v)))
-            .collect()
+        let mut env = serde_json::Map::new();
+        let mut argocd_env = Vec::new();
+
+        for (key, value) in vars {
+            if key.starts_with("NYL_") {
+                env.insert(key, serde_json::Value::String(value));
+            } else if let Some(key) = key.strip_prefix("ARGOCD_ENV_") {
+                if key.starts_with("NYL_") {
+                    argocd_env.push((key.to_string(), value));
+                }
+            }
+        }
+
+        for (key, value) in argocd_env {
+            env.insert(key, serde_json::Value::String(value));
+        }
+
+        env
     }
 }
 
@@ -199,21 +216,38 @@ mod tests {
             ("NYL_ANOTHER".to_string(), "also_visible".to_string()),
             ("PATH".to_string(), "/usr/bin".to_string()),
             ("NYL_CONFIG".to_string(), "test_config".to_string()),
+            ("ARGOCD_ENV_NYL_REGION".to_string(), "eu-central-1".to_string()),
+            ("ARGOCD_ENV_SECRET_KEY".to_string(), "still-hidden".to_string()),
         ];
 
         let filtered = TemplateContext::filter_env_vars(mock_vars.into_iter());
 
         // Check that only NYL_ prefixed vars are included
-        assert_eq!(filtered.len(), 3);
+        assert_eq!(filtered.len(), 4);
         assert!(filtered.contains_key("NYL_TEST_VAR"));
         assert_eq!(filtered.get("NYL_TEST_VAR").unwrap().as_str().unwrap(), "visible");
         assert!(filtered.contains_key("NYL_ANOTHER"));
         assert_eq!(filtered.get("NYL_ANOTHER").unwrap().as_str().unwrap(), "also_visible");
         assert!(filtered.contains_key("NYL_CONFIG"));
         assert_eq!(filtered.get("NYL_CONFIG").unwrap().as_str().unwrap(), "test_config");
+        assert_eq!(filtered.get("NYL_REGION").unwrap().as_str().unwrap(), "eu-central-1");
 
         // Verify non-NYL_ prefixed vars are excluded
         assert!(!filtered.contains_key("SECRET_KEY"));
         assert!(!filtered.contains_key("PATH"));
+        assert!(!filtered.contains_key("ARGOCD_ENV_NYL_REGION"));
+        assert!(!filtered.contains_key("ARGOCD_ENV_SECRET_KEY"));
+    }
+
+    #[test]
+    fn test_filter_env_vars_prefers_argocd_plugin_value() {
+        let mock_vars = vec![
+            ("ARGOCD_ENV_NYL_IMAGE_TAG".to_string(), "pr-build".to_string()),
+            ("NYL_IMAGE_TAG".to_string(), "inherited".to_string()),
+        ];
+
+        let filtered = TemplateContext::filter_env_vars(mock_vars.into_iter());
+
+        assert_eq!(filtered.get("NYL_IMAGE_TAG").unwrap().as_str().unwrap(), "pr-build");
     }
 }


### PR DESCRIPTION
## Summary

- align the ArgoCD bootstrap E2E assertions with the chart's `nyl-v2` sidecar contract
- run the Minikube integration job for same-repository pull requests, while keeping fork PRs excluded from the GHCR-dependent path
- remove the unrelated all-platform binary build dependency from the Minikube job
- install `cargo-audit` through the first-party `cargo-binstall` action using signed prebuilt binaries only
- update `crossbeam-epoch` to 0.9.20 so `cargo audit` clears RUSTSEC-2026-0204
- add project-controlled `ApplicationGenerator.spec.source.pluginEnv` values and forward the bootstrap artifact/repository coordinates to the self-managed CMP Application
- safely normalize ArgoCD's `ARGOCD_ENV_NYL_*` plugin parameters to their `NYL_*` template names
- make the E2E test observe self-sync through Kubernetes and reconnect after ArgoCD restarts its own API server
- use server-side apply for the self-managed Application so large ArgoCD CRDs do not exceed the annotation-size limit
- run the private-repository credential E2E only when its complete repository secret set is configured

## Test plan

- [x] `bash -n integrationtests/test-argocd-bootstrap.sh`
- [x] parse `.github/workflows/ci.yaml`
- [x] verify signed binary-only resolution for `cargo-audit` on `x86_64-unknown-linux-gnu`
- [x] render the bootstrap using only `ARGOCD_ENV_NYL_*` inputs and verify the generated CMP Application retains the PR chart, image, repository, revision, and server-side apply option
- [x] `cargo audit`
- [x] `env RUSTC_WRAPPER= mise run pre-commit`
- [x] confirm Quality Checks passes on GitHub Actions
- [x] confirm the ArgoCD bootstrap E2E syncs and becomes healthy on GitHub Actions
- [x] confirm the complete Integration tests (Minikube) job passes on GitHub Actions